### PR TITLE
feat(multisig.mon)

### DIFF
--- a/balances/cli.go
+++ b/balances/cli.go
@@ -58,7 +58,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    AccountsFlagName,
-			Usage:   "One or accounts formatted via `address:nickname",
+			Usage:   "One or accounts formatted via `address:nickname`",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "ACCOUNTS"),
 		},
 	}

--- a/balances/monitor.go
+++ b/balances/monitor.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	MetricsNamespace = "monitorism"
+	MetricsNamespace = "balances_mon"
 )
 
 type Account struct {

--- a/fault/monitor.go
+++ b/fault/monitor.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	MetricsNamespace = "monitorism"
+	MetricsNamespace = "fault_mon"
 )
 
 type Monitor struct {

--- a/multisig/cli.go
+++ b/multisig/cli.go
@@ -16,8 +16,7 @@ const (
 	OptimismPortalAddressFlagName = "optimismportal.address"
 	SafeAddressFlagName           = "safe.address"
 
-	OnePassServiceTokenFlagName = "op.service.token"
-	OnePassVaultFlagName        = "op.vault"
+	OnePassVaultFlagName = "op.vault"
 )
 
 type Account struct {
@@ -31,16 +30,13 @@ type CLIConfig struct {
 	L1NodeURL             string
 	OptimismPortalAddress common.Address
 	SafeAddress           common.Address
-
-	OnePassServiceToken string
-	OnePassVault        string
+	OnePassVault          string
 }
 
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 	cfg := CLIConfig{
-		L1NodeURL:           ctx.String(L1NodeURLFlagName),
-		OnePassServiceToken: ctx.String(OnePassServiceTokenFlagName),
-		OnePassVault:        ctx.String(OnePassVaultFlagName),
+		L1NodeURL:    ctx.String(L1NodeURLFlagName),
+		OnePassVault: ctx.String(OnePassVaultFlagName),
 	}
 
 	portalAddress := ctx.String(OptimismPortalAddressFlagName)
@@ -75,11 +71,6 @@ func CLIFlags(envVar string) []cli.Flag {
 			Name:    SafeAddressFlagName,
 			Usage:   "Address of the Safe contract",
 			EnvVars: opservice.PrefixEnvVar(envVar, "SAFE"),
-		},
-		&cli.StringFlag{
-			Name:    OnePassServiceTokenFlagName,
-			Usage:   "1Pass Service Token",
-			EnvVars: opservice.PrefixEnvVar(envVar, "1PASS_SERVICE_TOKEN"),
 		},
 		&cli.StringFlag{
 			Name:    OnePassVaultFlagName,

--- a/multisig/cli.go
+++ b/multisig/cli.go
@@ -1,0 +1,90 @@
+package multisig
+
+import (
+	"fmt"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	L1NodeURLFlagName = "l1.node.url"
+
+	OptimismPortalAddressFlagName = "optimismportal.address"
+	SafeAddressFlagName           = "safe.address"
+
+	OnePassServiceTokenFlagName = "op.service.token"
+	OnePassVaultFlagName        = "op.vault"
+)
+
+type Account struct {
+	Nickname              string
+	SafeAddress           string
+	OptimismPortalAddress string
+	Vault                 string
+}
+
+type CLIConfig struct {
+	L1NodeURL             string
+	OptimismPortalAddress common.Address
+	SafeAddress           common.Address
+
+	OnePassServiceToken string
+	OnePassVault        string
+}
+
+func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
+	cfg := CLIConfig{
+		L1NodeURL:           ctx.String(L1NodeURLFlagName),
+		OnePassServiceToken: ctx.String(OnePassServiceTokenFlagName),
+		OnePassVault:        ctx.String(OnePassVaultFlagName),
+	}
+
+	portalAddress := ctx.String(OptimismPortalAddressFlagName)
+	if !common.IsHexAddress(portalAddress) {
+		return cfg, fmt.Errorf("--%s is not a hex-encoded address", OptimismPortalAddressFlagName)
+	}
+	cfg.OptimismPortalAddress = common.HexToAddress(portalAddress)
+
+	safeAddress := ctx.String(SafeAddressFlagName)
+	if !common.IsHexAddress(safeAddress) {
+		return cfg, fmt.Errorf("--%s is not a hex-encoded address", SafeAddressFlagName)
+	}
+	cfg.SafeAddress = common.HexToAddress(safeAddress)
+
+	return cfg, nil
+}
+
+func CLIFlags(envVar string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    L1NodeURLFlagName,
+			Usage:   "Node URL of L1 peer",
+			Value:   "127.0.0.1:8545",
+			EnvVars: opservice.PrefixEnvVar(envVar, "L1_NODE_URL"),
+		},
+		&cli.StringFlag{
+			Name:    OptimismPortalAddressFlagName,
+			Usage:   "Address of the OptimismPortal contract",
+			EnvVars: opservice.PrefixEnvVar(envVar, "OPTIMISM_PORTAL"),
+		},
+		&cli.StringFlag{
+			Name:    SafeAddressFlagName,
+			Usage:   "Address of the Safe contract",
+			EnvVars: opservice.PrefixEnvVar(envVar, "SAFE"),
+		},
+		&cli.StringFlag{
+			Name:    OnePassServiceTokenFlagName,
+			Usage:   "1Pass Service Token",
+			EnvVars: opservice.PrefixEnvVar(envVar, "1PASS_SERVICE_TOKEN"),
+		},
+		&cli.StringFlag{
+			Name:    OnePassVaultFlagName,
+			Usage:   "1Pass Vault name",
+			EnvVars: opservice.PrefixEnvVar(envVar, "1PASS_VAULT_NAME"),
+		},
+	}
+}

--- a/multisig/monitor.go
+++ b/multisig/monitor.go
@@ -1,0 +1,170 @@
+package multisig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	MetricsNamespace = "multisig_mon"
+	SafeNonceABI     = "nonce()"
+)
+
+var (
+	SafeNonceSelector = crypto.Keccak256([]byte(SafeNonceABI))[:4]
+)
+
+type Monitor struct {
+	log log.Logger
+
+	l1Client *ethclient.Client
+
+	optimismPortalAddress common.Address
+	optimismPortal        *bindings.OptimismPortalCaller
+
+	onePassToken string
+	onePassVault string
+	safeAddress  common.Address
+
+	// metrics
+	safeNonce                 *prometheus.GaugeVec
+	latestPresignedPauseNonce *prometheus.GaugeVec
+	paused                    *prometheus.GaugeVec
+}
+
+func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig) (*Monitor, error) {
+	l1Client, err := ethclient.Dial(cfg.L1NodeURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial l1 rpc: %w", err)
+	}
+
+	optimismPortal, err := bindings.NewOptimismPortalCaller(cfg.OptimismPortalAddress, l1Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind to the OptimismPortal: %w", err)
+	}
+
+	return &Monitor{
+		log:      log,
+		l1Client: l1Client,
+
+		optimismPortal:        optimismPortal,
+		optimismPortalAddress: cfg.OptimismPortalAddress,
+
+		safeAddress:  cfg.SafeAddress,
+		onePassToken: cfg.OnePassServiceToken,
+		onePassVault: cfg.OnePassVault,
+
+		safeNonce: m.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "safeNonce",
+			Help:      "Safe Nonce",
+		}, []string{"address", "nickname"}),
+		latestPresignedPauseNonce: m.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "latestPresignedPauseNonce",
+			Help:      "Latest pre-signed pause nonce",
+		}, []string{"address", "nickname"}),
+		paused: m.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "pausedState",
+			Help:      "OptimismPortal paused state",
+		}, []string{"address", "nickname"}),
+	}, nil
+}
+
+func (m *Monitor) Run(ctx context.Context) {
+	m.checkOptimismPortal(ctx)
+	m.checkSafeNonce(ctx)
+	m.checkPresignedNonce(ctx)
+}
+
+func (m *Monitor) checkOptimismPortal(ctx context.Context) {
+	paused, err := m.optimismPortal.Paused(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		m.log.Error("failed to query OptimismPortal paused status", "err", err)
+		return
+	}
+
+	pausedMetric := 0
+	if paused {
+		pausedMetric = 1
+	}
+
+	m.paused.WithLabelValues(m.optimismPortalAddress.String(), "").Set(float64(pausedMetric))
+	m.log.Info("OptimismPortal status", "address", m.optimismPortalAddress.String(), "paused", paused)
+}
+
+func (m *Monitor) checkSafeNonce(ctx context.Context) {
+	nonceBytes := hexutil.Bytes{}
+	nonceTx := map[string]interface{}{"to": m.safeAddress, "data": hexutil.Encode(SafeNonceSelector)}
+	if err := m.l1Client.Client().CallContext(ctx, &nonceBytes, "eth_call", nonceTx, "latest"); err != nil {
+		m.log.Error("failed to query safe nonce", "err", err)
+		return
+	}
+
+	nonce := new(big.Int).SetBytes(nonceBytes).Uint64()
+	m.safeNonce.WithLabelValues(m.safeAddress.String(), "").Set(float64(nonce))
+	m.log.Info("Safe Nonce", "address", m.safeAddress.String(), "nonce", nonce)
+}
+
+func (m *Monitor) checkPresignedNonce(ctx context.Context) {
+	os.Setenv("OP_SERVICE_ACCOUNT_TOKEN", m.onePassToken)
+	cmd := exec.CommandContext(ctx, "op", "item", "list", "--format=json", fmt.Sprintf("--vault=%s", m.onePassVault))
+
+	output, err := cmd.Output()
+	if err != nil {
+		m.log.Error("failed to run op cli")
+		return
+	}
+
+	vaultItems := []struct{ Title string }{}
+	if err := json.Unmarshal(output, &vaultItems); err != nil {
+		m.log.Error("failed to unmarshal op cli stdout", "err", err)
+		return
+	}
+
+	latestPresignedNonce := int64(-1)
+	for _, item := range vaultItems {
+		if strings.HasPrefix(item.Title, "ready-") && strings.HasSuffix(item.Title, ".json") {
+			nonce, err := strconv.ParseInt(item.Title[6:len(item.Title)-5], 10, 64)
+			if err != nil {
+				m.log.Error("failed to parse nonce from item title", "title", item.Title)
+				return
+			}
+			if nonce > latestPresignedNonce {
+				latestPresignedNonce = nonce
+			}
+		}
+	}
+
+	m.latestPresignedPauseNonce.WithLabelValues(m.optimismPortalAddress.String(), "").Set(float64(latestPresignedNonce))
+	if latestPresignedNonce == -1 {
+		m.log.Error("no presigned nonce found")
+		return
+	}
+
+	m.log.Info("Latest Presigned Nonce", "nonce", latestPresignedNonce)
+}
+
+func (m *Monitor) Close(_ context.Context) error {
+	m.l1Client.Close()
+	return nil
+}

--- a/withdrawals/monitor.go
+++ b/withdrawals/monitor.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MetricsNamespace = "monitorism"
+	MetricsNamespace = "withdrawals_mon"
 
 	// event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
 	WithdrawalProvenEventABI = "WithdrawalProven(bytes32,address,address)"


### PR DESCRIPTION
helptext. `OP_SERVICE_ACCOUNT_TOKEN` must be set outside the process
```
   --l1.node.url value             Node URL of L1 peer (default: "127.0.0.1:8545") [$MULTISIG_MON_L1_NODE_URL]
   --optimismportal.address value  Address of the OptimismPortal contract [$MULTISIG_MON_OPTIMISM_PORTAL]
   --safe.address value            Address of the Safe contract [$MULTISIG_MON_SAFE]
   --op.vault value                1Pass Vault name [$MULTISIG_MON_1PASS_VAULT_NAME]
```

Sample Output (with a sample vault on my computer):
```
hamdiallam@hamdioplabsmbp monitorism % go run ./cmd/monitorism multisig --l1.node.url https://rpc.ankr.com/eth --optimismportal.address 0xbEb5Fc579115071764c7423A4f12eDde41f106Ed --safe.address 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A --loop.interval.msec 1_000 --op.vault Hypatia --op.service.token $(echo $OP_SERVICE_ACCOUNT_TOKEN)
INFO [05-01|18:39:02.146] starting metrics server                  host=0.0.0.0 port=7300
INFO [05-01|18:39:02.147] starting monitor...                      loop_interval_ms=1000
INFO [05-01|18:39:02.316] OptimismPortal status                    address=0xbEb5Fc579115071764c7423A4f12eDde41f106Ed paused=false
INFO [05-01|18:39:02.403] Safe Nonce                               address=0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A nonce=92
INFO [05-01|18:39:03.030] Latest Presigned Nonce                   nonce=42069

```