### PR TITLE
chore: add the rules directly into the docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ temp
 coverage.json
 *.tsbuildinfo
 **/lcov.info
-
+docker.sh
 yarn-error.log
 .yarn/*
 !.yarn/releases

--- a/op-monitorism/Dockerfile
+++ b/op-monitorism/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:3.18
 
 # Copy the built binary from the builder stage
 COPY --from=builder /app/bin/monitorism /usr/local/bin/monitorism
-
+COPY --from=builder /app/global_events/rules/ /usr/local/config/
 # Ensure the binary is executable
 RUN chmod +x /usr/local/bin/monitorism
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add the yaml rules of `global_events` directly into the docker to allow `global_events` to fetch them from here.
Also added into the `.gitignore` a file `docker.sh` to avoid to push unecessary files. 