### PR TITLE
Fix: Incorrect Filtering Listen to wide the events.

### DIFF
--- a/op-monitorism/global_events/monitor_test.go
+++ b/op-monitorism/global_events/monitor_test.go
@@ -31,11 +31,6 @@ func TestFormatSignature(t *testing.T) {
 			input:          " approve ( address spender , uint256 value ) ",
 			expectedOutput: "approve(address,uint256)",
 		},
-		// {
-		// 	name:           "Uniswap swap",
-		// 	input:          "Swap (address sender,address recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)",
-		// 	expectedOutput: "Swap(address,address,int256,int256,uint160,uint128,int24)",
-		// },
 		{
 			name:           "Uniswap swap",
 			input:          "Swap (address sender,address recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)",

--- a/op-monitorism/global_events/monitor_test.go
+++ b/op-monitorism/global_events/monitor_test.go
@@ -1,6 +1,7 @@
 package global_events
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"testing"
 )
 
@@ -30,6 +31,16 @@ func TestFormatSignature(t *testing.T) {
 			input:          " approve ( address spender , uint256 value ) ",
 			expectedOutput: "approve(address,uint256)",
 		},
+		// {
+		// 	name:           "Uniswap swap",
+		// 	input:          "Swap (address sender,address recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)",
+		// 	expectedOutput: "Swap(address,address,int256,int256,uint160,uint128,int24)",
+		// },
+		{
+			name:           "Uniswap swap",
+			input:          "Swap (address sender,address recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)",
+			expectedOutput: "Swap(address,address,int256,int256,uint160,uint128,int24)",
+		},
 		{
 			name:           "Invalid Input",
 			input:          "invalidInput",
@@ -40,6 +51,29 @@ func TestFormatSignature(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			output := formatSignature(test.input)
+			if output != test.expectedOutput {
+				t.Errorf("Failed %s: expected %q but got %q", test.name, test.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestFormatAndHash(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput common.Hash
+	}{
+		{
+			name:           "Uniswap swap",
+			input:          "Swap (address indexed sender,address recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)",
+			expectedOutput: common.HexToHash("0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := FormatAndHash(test.input)
 			if output != test.expectedOutput {
 				t.Errorf("Failed %s: expected %q but got %q", test.name, test.expectedOutput, output)
 			}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix the incorrect filtering by ensuring only the addresses specifed into the yaml is listenning at.
Also add a test to ensure the formatHash is working with more complexe event topics.


**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
