### PR TITLE
patch: fix bug sending the wrong function name into the grafana metrics.

### DIFF
--- a/op-monitorism/global_events/monitor.go
+++ b/op-monitorism/global_events/monitor.go
@@ -208,8 +208,9 @@ func (m *Monitor) checkEvents(ctx context.Context) { //TODO: Ensure the logs cri
 					continue
 				}
 				// We matched an alert!
-				m.log.Info("Event Detected", "TxHash", vLog.TxHash.String(), "Address", vLog.Address, "Topics", vLog.Topics, "Config", config)
-				m.eventEmitted.WithLabelValues(m.nickname, config.Name, config.Priority, config.Events[0].Signature, config.Events[0].Keccak256_Signature.Hex(), vLog.Address.String(), latestBlockNumber.String(), vLog.TxHash.String()).Set(float64(1))
+				event_config := ReturnAndEventForAnTopic(vLog.Topics[0], config)
+				m.log.Info("Event Detected", "TxHash", vLog.TxHash.String(), "Address", vLog.Address, "Topics", vLog.Topics, "Config", config, "event_config.Signature", event_config.Signature, "event_config.Keccak256_Signature", event_config.Keccak256_Signature.Hex())
+				m.eventEmitted.WithLabelValues(m.nickname, config.Name, config.Priority, event_config.Signature, event_config.Keccak256_Signature.Hex(), vLog.Address.String(), latestBlockNumber.String(), vLog.TxHash.String()).Set(float64(1))
 			}
 		}
 	}
@@ -231,6 +232,16 @@ func ReturnConfigFromConfigsAndAddress(address common.Address, configs []Configu
 		}
 	}
 	return configDefault
+}
+
+// ReturnEventsMonitoredForAnAddressFromAConfig return a full `Event` struct for a topic and a config.
+func ReturnAndEventForAnTopic(topic common.Hash, config Configuration) Event {
+	for _, event := range config.Events {
+		if topic == event.Keccak256_Signature {
+			return event
+		}
+	}
+	return Event{}
 }
 
 // Close closes the monitor.


### PR DESCRIPTION
 Fix a bug sending the wrong function name into the grafana metrics.
This was cause because the metrics sent was hardcoded on the `[0]` which can cause an issue when the rules has more than one event monitored. 