### PR TITLE
Fix the previous metrics by using a counter into `global_event`. 

### DIFF
--- a/op-monitorism/global_events/monitor.go
+++ b/op-monitorism/global_events/monitor.go
@@ -212,7 +212,7 @@ func (m *Monitor) checkEvents(ctx context.Context) { //TODO: Ensure the logs cri
 				m.log.Info("Event Detected", "TxHash", vLog.TxHash.String(), "Address", vLog.Address, "Topics", vLog.Topics, "Config", config, "event_config.Signature", event_config.Signature, "event_config.Keccak256_Signature", event_config.Keccak256_Signature.Hex())
 				// m.eventEmitted.WithLabelValues(m.nickname, config.Name, config.Priority, event_config.Signature, event_config.Keccak256_Signature.Hex(), vLog.Address.String(), latestBlockNumber.String(), vLog.TxHash.String()).Set(float64(1)) //inc
 
-				m.eventEmitted.WithLabelValues(m.nickname, config.Name, config.Priority, event_config.Signature, vLog.Address.String(), latestBlockNumber.String(), vLog.TxHash.String()).Inc()
+				m.eventEmitted.WithLabelValues(m.nickname, config.Name, config.Priority, event_config.Signature, event_config.Keccak256_Signature.Hex(), vLog.Address.String(), latestBlockNumber.String(), vLog.TxHash.String()).Inc()
 			}
 		}
 	}

--- a/op-monitorism/global_events/types.go
+++ b/op-monitorism/global_events/types.go
@@ -172,10 +172,8 @@ func (G GlobalConfiguration) DisplayMonitorAddresses(log log.Logger) {
 			}
 		} else {
 			for _, address := range config.Addresses {
-				// log.Info("", "", "", "Address", address)
 				log.Info("   ", " Address", address)
 				for _, events := range G.ReturnEventsMonitoredForAnAddressFromAConfig(address, config) {
-					// log.Info("", "", "", "", "", "Events", events)
 					log.Info("", "    Events", events)
 				}
 			}

--- a/op-monitorism/global_events/types.go
+++ b/op-monitorism/global_events/types.go
@@ -172,9 +172,11 @@ func (G GlobalConfiguration) DisplayMonitorAddresses(log log.Logger) {
 			}
 		} else {
 			for _, address := range config.Addresses {
-				log.Info("", "", "", "Address", address)
+				// log.Info("", "", "", "Address", address)
+				log.Info("   ", " Address", address)
 				for _, events := range G.ReturnEventsMonitoredForAnAddressFromAConfig(address, config) {
-					log.Info("", "", "", "", "", "Events", events)
+					// log.Info("", "", "", "", "", "Events", events)
+					log.Info("", "    Events", events)
 				}
 			}
 		}


### PR DESCRIPTION
Fix the metrics and also refactor the log at the start of the service. 
Fix a panic from cardinality issue: 

```bash
panic: inconsistent label cardinality: expected 8 label values but got 7 in []string{"lskjdflskjdflskjfsdjkf", "Template SafeExecution Events (Success/Failure) L1 ETHEREUM", "P5", "ExecutionSuccess(bytes32,uint256)", "0x19c50EFcbFBd2b704f14F6c2Bd0B0E508635Dbe0", "20127231", "0x33cf84d899482baaf994483558c9d14d7768f1e24af4edd9ce29c313d294c3c8"}

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(...)
        /Users/ethnical/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/counter.go:284
github.com/ethereum-optimism/monitorism/op-monitorism/global_events.(*Monitor).checkEvents(0x1400015ce00, {0x2?, 0x2?})
        /Users/ethnical/sec/ethereum-optimism/monitorism/op-monitorism/global_events/monitor.go:215 +0xd00
github.com/ethereum-optimism/monitorism/op-monitorism/global_events.(*Monitor).Run(0x2ee0?, {0x105c8ca30?, 0x1400011a2d0?})
        /Users/ethnical/sec/ethereum-optimism/monitorism/op-monitorism/global_events/monitor.go:150 +0x24
github.com/ethereum-optimism/monitorism/op-monitorism.(*cliApp).Start(0x14000266d20, {0x105c8ca30, 0x1400011a2d0})
        /Users/ethnical/sec/ethereum-optimism/monitorism/op-monitorism/monitorism.go:86 +0x228
main.newCli.LifecycleCmd.func8(0x14000117640)
        /Users/ethnical/go/pkg/mod/github.com/ethereum-optimism/optimism@v1.7.3/op-service/cliapp/lifecycle.go:65 +0x1dc
github.com/urfave/cli/v2.(*Command).Run(0x1400057a000, 0x14000117640, {0x1400072a160, 0xb, 0xb})
        /Users/ethnical/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:279 +0x71c
github.com/urfave/cli/v2.(*Command).Run(0x14000726160, 0x140001174c0, {0x14000168000, 0xc, 0xc})
        /Users/ethnical/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:272 +0x918
github.com/urfave/cli/v2.(*App).RunContext(0x14000578000, {0x105c8c9f8, 0x140005be000}, {0x14000168000, 0xc, 0xc})
        /Users/ethnical/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:337 +0x514
main.main()
        /Users/ethnical/sec/ethereum-optimism/monitorism/op-monitorism/cmd/monitorism/main.go:24 +0x80
exit status 2
```
