### PR TITLE
Adding new monitor (Safe Liveness Expiration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,58 @@
 # Monitorism
+
 A blockchain surveillance tool that supports monitoring for the OP Stack and EVM-compatible chains.
 
-⚠️  Caution: *Monitorism* is currently in its beta phase and is under active migration 🔨. This implies that *Monitorism* is presently not fully stable. ⚠️
+## Monitors
+
+In addition the common configuration, each monitor also has their specific configuration
+
+- **Note**: The environment variable prefix for monitor-specific configuration is different than the global monitor config described above.
+
+### Fault Monitor
+
+The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract. On change, reconstructing the output root from a trusted L2 source and looking for a match
+`op-monitorism/fault` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/fault/README.md#L1
+
+### Withdrawals Monitor
+
+The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract. Each withdrawal is checked against the `L2ToL1MessagePasser` contract
+`op-monitorism/withdrawals` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/withdrawals/README.md#L1
+
+### Balances Monitor
+
+The balances monitor simply emits a metric reporting the balances for the configured accounts.
+`op-monitorism/balances` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/balances/README.md#L1
+
+### Multisig Monitor
+
+The multisig monitor reports the paused status of the `OptimismPortal` contract. If set, the latest nonce of the configued `Safe` address. And also if set, the latest presigned nonce stored in One Password. The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name. The highest nonce of this item name format is reported.
+
+`op-monitorism/multisig` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/multisig/README.md#L1
+
+### Drippie Monitor
+
+The drippie monitor tracks the execution and executability of drips within a Drippie contract.
+`op-monitorism/drippie` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/drippie/README.md#L1
+
+### Secrets Monitor
+
+The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
+`op-monitorism/secrets` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/secrets/README.md#L1
+
+### Global Events Monitor
+
+The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
+`op-monitorism/global_events` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/global_events/README.md#L1
+
+### Liveness Expiration Monitor
+
+The Liveness Expiration Monitor is made for monitoring the liveness expiration on Safes.
+`op-monitorism/liveness_expiration` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/liveness_expiration/README.md#L1
+
+## CLI and Docs
 
 The cli has the ability to spin up a monitor for varying activities, each emmitting metrics used to setup alerts.
+
 ```
 COMMANDS:
    multisig     Monitors OptimismPortal pause status, Safe nonce, and Pre-Signed nonce stored in 1Password
@@ -14,104 +63,14 @@ COMMANDS:
 ```
 
 Each monitor has some common configuration, configurable both via cli or env with defaults.
-```
-OPTIONS:
-   --log.level value           [$MONITORISM_LOG_LEVEL]           The lowest log level that will be output (default: INFO)                                                       
-   --log.format value          [$MONITORISM_LOG_FORMAT]          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) 
-   --log.color                 [$MONITORISM_LOG_COLOR]           Color the log output if in terminal mode (default: false)                                                      
-   --metrics.enabled           [$MONITORISM_METRICS_ENABLED]     Enable the metrics server (default: false)                                                                     
-   --metrics.addr value        [$MONITORISM_METRICS_ADDR]        Metrics listening address (default: "0.0.0.0")                                                                 
-   --metrics.port value        [$MONITORISM_METRICS_PORT]        Metrics listening port (default: 7300)                                                                         
-   --loop.interval.msec value  [$MONITORISM_LOOP_INTERVAL_MSEC]  Loop interval of the monitor in milliseconds (default: 60000)                                                  
-```
-
-## Monitors
-
-In addition the common configuration, each monitor also has their specific configuration
-
-* **Note**: The environment variable prefix for monitor-specific configuration is different than the global monitor config described above.
-
-### Fault Monitor
-
-The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract. On change, reconstructing the output root from a trusted L2 source and looking for a match
-```
-OPTIONS:
-   --l1.node.url value             [$FAULT_MON_L1_NODE_URL]         Node URL of L1 peer (default: "127.0.0.1:8545")                              
-   --l2.node.url value             [$FAULT_MON_L2_NODE_URL]         Node URL of L2 peer (default: "127.0.0.1:9545")                              
-   --start.output.index value      [$FAULT_MON_START_OUTPUT_INDEX]  Output index to start from. -1 to find first unfinalized index (default: -1) 
-   --optimismportal.address value  [$FAULT_MON_OPTIMISM_PORTAL]     Address of the OptimismPortal contract                                       
-```
-
-On mismatch the `isCurrentlyMismatched` metrics is set to `1`.
-
-### Withdrawals Monitor
-
-The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract. Each withdrawal is checked against the `L2ToL1MessagePasser` contract
-```
-OPTIONS:
-   --l1.node.url value             [$WITHDRAWAL_MON_L1_NODE_URL]         Node URL of L1 peer (default: "127.0.0.1:8545")          
-   --l2.node.url value             [$WITHDRAWAL_MON_L2_NODE_URL]         Node URL of L2 peer (default: "127.0.0.1:9545")          
-   --event.block.range value       [$WITHDRAWAL_MON_EVENT_BLOCK_RANGE]   Max block range when scanning for events (default: 1000) 
-   --start.block.height value      [$WITHDRAWAL_MON_START_BLOCK_HEIGHT]  Starting height to scan for events                       
-   --optimismportal.address value  [$WITHDRAWAL_MON_OPTIMISM_PORTAL]     Address of the OptimismPortal contract                   
-```
-
-If a proven withdrawal is missing from L2, the `isDetectingForgeries` metrics is set to `1`.
-
-### Balances Monitor
-
-The balances monitor simply emits a metric reporting the balances for the configured accounts.
-```
-OPTIONS:
-   --node.url value                                             [$BALANCE_MON_NODE_URL]  Node URL of a peer (default: "127.0.0.1:8545") 
-   --accounts address:nickname [ --accounts address:nickname ]  [$BALANCE_MON_ACCOUNTS]  One or accounts formatted via address:nickname 
-```
-
-### Multisig Monitor
-
-The multisig monitor reports the paused status of the `OptimismPortal` contract. If set, the latest nonce of the configued `Safe` address. And also if set, the latest presigned nonce stored in One Password. The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name. The highest nonce of this item name format is reported.
-
-* **NOTE**: In order to read from one password, the `OP_SERVICE_ACCOUNT_TOKEN` environment variable must be set granting the process permission to access the specified vault.
 
 ```
 OPTIONS:
-   --l1.node.url value             [$MULTISIG_MON_L1_NODE_URL]       Node URL of L1 peer (default: "127.0.0.1:8545")                                               
-   --optimismportal.address value  [$MULTISIG_MON_OPTIMISM_PORTAL]   Address of the OptimismPortal contract                                                        
-   --nickname value                [$MULTISIG_MON_NICKNAME]          Nickname of chain being monitored                                                             
-   --safe.address value            [$MULTISIG_MON_SAFE]              Address of the Safe contract                                                                  
-   --op.vault value                [$MULTISIG_MON_1PASS_VAULT_NAME]  1Pass Vault name storing presigned safe txs following a 'ready-<nonce>.json' item name format 
-```
-
-### Drippie Monitor
-
-The drippie monitor tracks the execution and executability of drips within a Drippie contract.
-
-```
-OPTIONS:
-   --l1.node.url value         Node URL of L1 peer (default: "127.0.0.1:8545") [$DRIPPIE_MON_L1_NODE_URL]
-   --drippie.address value     Address of the Drippie contract [$DRIPPIE_MON_DRIPPIE]
-   --log.level value           The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
-   --log.format value          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
-   --log.color                 Color the log output if in terminal mode (default: false) [$MONITORISM_LOG_COLOR]
-   --metrics.enabled           Enable the metrics server (default: false) [$MONITORISM_METRICS_ENABLED]
-   --metrics.addr value        Metrics listening address (default: "0.0.0.0") [$MONITORISM_METRICS_ADDR]
-   --metrics.port value        Metrics listening port (default: 7300) [$MONITORISM_METRICS_PORT]
-   --loop.interval.msec value  Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
-```
-
-### Secrets Monitor
-
-The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
-
-```
-OPTIONS:
-   --l1.node.url value         Node URL of L1 peer (default: "127.0.0.1:8545") [$SECRETS_MON_L1_NODE_URL]
-   --drippie.address value     Address of the Drippie contract [$SECRETS_MON_DRIPPIE]
-   --log.level value           The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
-   --log.format value          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
-   --log.color                 Color the log output if in terminal mode (default: false) [$MONITORISM_LOG_COLOR]
-   --metrics.enabled           Enable the metrics server (default: false) [$MONITORISM_METRICS_ENABLED]
-   --metrics.addr value        Metrics listening address (default: "0.0.0.0") [$MONITORISM_METRICS_ADDR]
-   --metrics.port value        Metrics listening port (default: 7300) [$MONITORISM_METRICS_PORT]
-   --loop.interval.msec value  Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
+   --log.level value           [$MONITORISM_LOG_LEVEL]           The lowest log level that will be output (default: INFO)
+   --log.format value          [$MONITORISM_LOG_FORMAT]          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text)
+   --log.color                 [$MONITORISM_LOG_COLOR]           Color the log output if in terminal mode (default: false)
+   --metrics.enabled           [$MONITORISM_METRICS_ENABLED]     Enable the metrics server (default: false)
+   --metrics.addr value        [$MONITORISM_METRICS_ADDR]        Metrics listening address (default: "0.0.0.0")
+   --metrics.port value        [$MONITORISM_METRICS_PORT]        Metrics listening port (default: 7300)
+   --loop.interval.msec value  [$MONITORISM_LOOP_INTERVAL_MSEC]  Loop interval of the monitor in milliseconds (default: 60000)
 ```

--- a/README.md
+++ b/README.md
@@ -7,47 +7,45 @@ A blockchain surveillance tool that supports monitoring for the OP Stack and EVM
 The list of all the monitors currently built into monitorism is below.
 
 ### Global Events Monitor
- ![df2b94999628ce8eee98fb60f45667e54be9b13db82add6aa77888f355137329](https://github.com/ethereum-optimism/monitorism/assets/23560242/b8d36a0f-8a17-4e22-be5a-3e9f3586b3ab)
+
+![df2b94999628ce8eee98fb60f45667e54be9b13db82add6aa77888f355137329](https://github.com/ethereum-optimism/monitorism/assets/23560242/b8d36a0f-8a17-4e22-be5a-3e9f3586b3ab)
 
 The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
 
-| `op-monitorism/global_events` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/global_events/README.md) |
-| - | - |
+| `op-monitorism/global_events` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/global_events/README.md) |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------- |
 
 ### Liveness Expiration Monitor
 
- ![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)
-
+![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)
 
 The Liveness Expiration Monitor is made for monitoring the liveness expiration on Safes.
 
-| `op-monitorism/liveness_expiration` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/liveness_expiration/README.md) |
-| - | - |
-
+| `op-monitorism/liveness_expiration` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/liveness_expiration/README.md) |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 
 ### Fault Monitor
 
- The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract.
- On change, reconstructing the output root from a trusted L2 source and looking for a match.
+The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract.
+On change, reconstructing the output root from a trusted L2 source and looking for a match.
 
-| `op-monitorism/fault` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/fault/README.md) |
-| - | - |
+| `op-monitorism/fault` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/fault/README.md) |
+| --------------------- | ------------------------------------------------------------------------------------------------- |
 
 ### Withdrawals Monitor
 
- The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract.
- Each withdrawal is checked against the `L2ToL1MessagePasser` contract.
+The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract.
+Each withdrawal is checked against the `L2ToL1MessagePasser` contract.
 
-
-| `op-monitorism/withdrawals` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/withdrawals/README.md) |
-| - | - |
+| `op-monitorism/withdrawals` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/withdrawals/README.md) |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- |
 
 ### Balances Monitor
 
 The balances monitor simply emits a metric reporting the balances for the configured accounts.
 
-| `op-monitorism/balances` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/balances/README.md) |
-| - | - |
+| `op-monitorism/balances` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/balances/README.md) |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- |
 
 ### Multisig Monitor
 
@@ -56,22 +54,22 @@ If set, the latest nonce of the configued `Safe` address. And also if set, the l
 The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name.
 The highest nonce of this item name format is reported.
 
-| `op-monitorism/multisig` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/multisig/README.md) |
-| - | - |
+| `op-monitorism/multisig` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/multisig/README.md) |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- |
 
 ### Drippie Monitor
 
 The drippie monitor tracks the execution and executability of drips within a Drippie contract.
 
-| `op-monitorism/drippie` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/drippie/README.md) |
-| - | - |
+| `op-monitorism/drippie` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/multisig/README.md) |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
 
 ### Secrets Monitor
 
 The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
 
-| `op-monitorism/secrets` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/secrets/README.md) |
-| - | - |
+| `op-monitorism/secrets` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/multisig/README.md) |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
 
 ## CLI and Docs
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The list of all the monitors currently built into monitorism is below.
 
 ![df2b94999628ce8eee98fb60f45667e54be9b13db82add6aa77888f355137329](https://github.com/ethereum-optimism/monitorism/assets/23560242/b8d36a0f-8a17-4e22-be5a-3e9f3586b3ab)
 
-The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
+The Global Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
 
 | `op-monitorism/global_events` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/global_events/README.md) |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -10,43 +10,54 @@ In addition the common configuration, each monitor also has their specific confi
 
 ### Fault Monitor
 
-The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract. On change, reconstructing the output root from a trusted L2 source and looking for a match
+The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract.
+On change, reconstructing the output root from a trusted L2 source and looking for a match.
 `op-monitorism/fault` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/fault/README.md#L1
 
 ### Withdrawals Monitor
 
-The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract. Each withdrawal is checked against the `L2ToL1MessagePasser` contract
+The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract.
+Each withdrawal is checked against the `L2ToL1MessagePasser` contract.
+
 `op-monitorism/withdrawals` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/withdrawals/README.md#L1
 
 ### Balances Monitor
 
 The balances monitor simply emits a metric reporting the balances for the configured accounts.
+
 `op-monitorism/balances` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/balances/README.md#L1
 
 ### Multisig Monitor
 
-The multisig monitor reports the paused status of the `OptimismPortal` contract. If set, the latest nonce of the configued `Safe` address. And also if set, the latest presigned nonce stored in One Password. The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name. The highest nonce of this item name format is reported.
+The multisig monitor reports the paused status of the `OptimismPortal` contract.
+If set, the latest nonce of the configued `Safe` address. And also if set, the latest presigned nonce stored in One Password.
+The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name.
+The highest nonce of this item name format is reported.
 
 `op-monitorism/multisig` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/multisig/README.md#L1
 
 ### Drippie Monitor
 
 The drippie monitor tracks the execution and executability of drips within a Drippie contract.
+
 `op-monitorism/drippie` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/drippie/README.md#L1
 
 ### Secrets Monitor
 
 The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
+
 `op-monitorism/secrets` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/secrets/README.md#L1
 
 ### Global Events Monitor
 
 The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
+
 `op-monitorism/global_events` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/global_events/README.md#L1
 
 ### Liveness Expiration Monitor
 
 The Liveness Expiration Monitor is made for monitoring the liveness expiration on Safes.
+
 `op-monitorism/liveness_expiration` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/liveness_expiration/README.md#L1
 
 ## CLI and Docs

--- a/README.md
+++ b/README.md
@@ -2,30 +2,52 @@
 
 A blockchain surveillance tool that supports monitoring for the OP Stack and EVM-compatible chains.
 
-## Monitors
+## Monitors Component
 
-In addition the common configuration, each monitor also has their specific configuration
+The list of all the monitors currently built into monitorism is below.
 
-- **Note**: The environment variable prefix for monitor-specific configuration is different than the global monitor config described above.
+### Global Events Monitor
+ ![df2b94999628ce8eee98fb60f45667e54be9b13db82add6aa77888f355137329](https://github.com/ethereum-optimism/monitorism/assets/23560242/b8d36a0f-8a17-4e22-be5a-3e9f3586b3ab)
+
+The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
+
+| `op-monitorism/global_events` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/global_events/README.md) |
+| - | - |
+
+### Liveness Expiration Monitor
+
+ ![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)
+
+
+The Liveness Expiration Monitor is made for monitoring the liveness expiration on Safes.
+
+| `op-monitorism/liveness_expiration` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/liveness_expiration/README.md) |
+| - | - |
+
 
 ### Fault Monitor
 
-The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract.
-On change, reconstructing the output root from a trusted L2 source and looking for a match.
-`op-monitorism/fault` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/fault/README.md#L1
+ The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract.
+ On change, reconstructing the output root from a trusted L2 source and looking for a match.
+
+| `op-monitorism/fault` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/fault/README.md) |
+| - | - |
 
 ### Withdrawals Monitor
 
-The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract.
-Each withdrawal is checked against the `L2ToL1MessagePasser` contract.
+ The withdrawals monitor checks for new withdrawals that have been proven to the `OptimismPortal` contract.
+ Each withdrawal is checked against the `L2ToL1MessagePasser` contract.
 
-`op-monitorism/withdrawals` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/withdrawals/README.md#L1
+
+| `op-monitorism/withdrawals` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/withdrawals/README.md) |
+| - | - |
 
 ### Balances Monitor
 
 The balances monitor simply emits a metric reporting the balances for the configured accounts.
 
-`op-monitorism/balances` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/balances/README.md#L1
+| `op-monitorism/balances` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/balances/README.md) |
+| - | - |
 
 ### Multisig Monitor
 
@@ -34,31 +56,22 @@ If set, the latest nonce of the configued `Safe` address. And also if set, the l
 The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name.
 The highest nonce of this item name format is reported.
 
-`op-monitorism/multisig` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/multisig/README.md#L1
+| `op-monitorism/multisig` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/multisig/README.md) |
+| - | - |
 
 ### Drippie Monitor
 
 The drippie monitor tracks the execution and executability of drips within a Drippie contract.
 
-`op-monitorism/drippie` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/drippie/README.md#L1
+| `op-monitorism/drippie` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/drippie/README.md) |
+| - | - |
 
 ### Secrets Monitor
 
 The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
 
-`op-monitorism/secrets` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/secrets/README.md#L1
-
-### Global Events Monitor
-
-The Gloval Events Monitor is made for to taking YAML rules as configuration and monitoring the events that are emitted on the chain.
-
-`op-monitorism/global_events` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/global_events/README.md#L1
-
-### Liveness Expiration Monitor
-
-The Liveness Expiration Monitor is made for monitoring the liveness expiration on Safes.
-
-`op-monitorism/liveness_expiration` -> https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/liveness_expiration/README.md#L1
+| `op-monitorism/secrets` | [README](https://github.com/ethereum-optimism/monitorism/blob/aba37ff58b3503018ae5dbad5e5473af670834bc/op-monitorism/secrets/README.md) |
+| - | - |
 
 ## CLI and Docs
 

--- a/op-monitorism/balances/README.md
+++ b/op-monitorism/balances/README.md
@@ -1,0 +1,9 @@
+### Balances Monitor
+
+The balances monitor simply emits a metric reporting the balances for the configured accounts.
+
+```
+OPTIONS:
+   --node.url value                                             [$BALANCE_MON_NODE_URL]  Node URL of a peer (default: "127.0.0.1:8545")
+   --accounts address:nickname [ --accounts address:nickname ]  [$BALANCE_MON_ACCOUNTS]  One or accounts formatted via address:nickname
+```

--- a/op-monitorism/drippie/README.md
+++ b/op-monitorism/drippie/README.md
@@ -1,0 +1,16 @@
+### Drippie Monitor
+
+The drippie monitor tracks the execution and executability of drips within a Drippie contract.
+
+```
+OPTIONS:
+   --l1.node.url value         Node URL of L1 peer (default: "127.0.0.1:8545") [$DRIPPIE_MON_L1_NODE_URL]
+   --drippie.address value     Address of the Drippie contract [$DRIPPIE_MON_DRIPPIE]
+   --log.level value           The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
+   --log.format value          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
+   --log.color                 Color the log output if in terminal mode (default: false) [$MONITORISM_LOG_COLOR]
+   --metrics.enabled           Enable the metrics server (default: false) [$MONITORISM_METRICS_ENABLED]
+   --metrics.addr value        Metrics listening address (default: "0.0.0.0") [$MONITORISM_METRICS_ADDR]
+   --metrics.port value        Metrics listening port (default: 7300) [$MONITORISM_METRICS_PORT]
+   --loop.interval.msec value  Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
+```

--- a/op-monitorism/fault/README.md
+++ b/op-monitorism/fault/README.md
@@ -1,0 +1,13 @@
+### Fault Monitor
+
+The fault monitor checks for changes in output roots posted to the `L2OutputOracle` contract. On change, reconstructing the output root from a trusted L2 source and looking for a match
+
+```
+OPTIONS:
+   --l1.node.url value             [$FAULT_MON_L1_NODE_URL]         Node URL of L1 peer (default: "127.0.0.1:8545")
+   --l2.node.url value             [$FAULT_MON_L2_NODE_URL]         Node URL of L2 peer (default: "127.0.0.1:9545")
+   --start.output.index value      [$FAULT_MON_START_OUTPUT_INDEX]  Output index to start from. -1 to find first unfinalized index (default: -1)
+   --optimismportal.address value  [$FAULT_MON_OPTIMISM_PORTAL]     Address of the OptimismPortal contract
+```
+
+On mismatch the `isCurrentlyMismatched` metrics is set to `1`.

--- a/op-monitorism/liveness_expiration/README.md
+++ b/op-monitorism/liveness_expiration/README.md
@@ -1,7 +1,7 @@
 # Liveness expiration Monitoring
 
 This Liveness expiration module is a monitoring dedicated for the safes of the Optimism network.
-Ensuring that owners that operates the safes or any important actions are still actives enough.
+Ensuring that owners that operates the safes and performs any important actions are still actives enough.
 
 ![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)
 
@@ -41,6 +41,8 @@ This tools allows the monitoring of multiples metrics like:
 `highestBlockNumber`: The lastest block number height on L1.
 `lastLiveOfAOwner`: Get the last activities for a given safe owner on L1.
 `intervalLiveness`: the interval (in seconds) from the LivenessModule on L1.
+
+The logic for the rules detection is not inside the binary `liveness_expiration` as this is integrated with prometheus. The rules are located in the Prometheus/Grafana side.
 
 ### Execution
 

--- a/op-monitorism/liveness_expiration/README.md
+++ b/op-monitorism/liveness_expiration/README.md
@@ -1,0 +1,61 @@
+# Liveness expiration Monitoring
+
+This Liveness expiration module is a monitoring dedicated for the safes of the Optimism network.
+Ensuring that owners that operates the safes or any important actions are still actives enough.
+
+![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)
+
+## CLI and Docs:
+
+```bash
+NAME:
+   Monitorism liveness_expiration - Monitor the liveness expiration on Gnosis Safe.
+
+USAGE:
+   Monitorism liveness_expiration [command options] [arguments...]
+
+DESCRIPTION:
+   Monitor the liveness expiration on Gnosis Safe.
+
+OPTIONS:
+   --l1.node.url value             Node URL of L1 peer (default: "127.0.0.1:8545") [$LIVENESS_EXPIRATION_MON_L1_NODE_URL]
+   --start.block.height value      Starting height to scan for events (still not implemented for now.. The monitoring will start at the last block number) (default: 0) [$LIVENESS_EXPIRATION_MON_START_BLOCK_HEIGHT]
+   --livenessmodule.address value  Address of the LivenessModuleAddress contract [$LIVENESS_EXPIRATION_MON_LIVENESS_MODULE_ADDRESS]
+   --livenessguard.address value   Address of the LivenessGuardAddress contract [$LIVENESS_EXPIRATION_MON_LIVENESS_GUARD_ADDRESS]
+   --safe.address value            Address of the safe contract [$LIVENESS_EXPIRATION_MON_SAFE_ADDRESS]
+   --log.level value               The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
+   --log.format value              Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
+   --log.color                     Color the log output if in terminal mode (default: false) [$MONITORISM_LOG_COLOR]
+   --metrics.enabled               Enable the metrics server (default: false) [$MONITORISM_METRICS_ENABLED]
+   --metrics.addr value            Metrics listening address (default: "0.0.0.0") [$MONITORISM_METRICS_ADDR]
+   --metrics.port value            Metrics listening port (default: 7300) [$MONITORISM_METRICS_PORT]
+   --loop.interval.msec value      Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
+   --help, -h                      show help
+```
+
+### Informations
+
+This tools allows the monitoring of multiples metrics like:
+
+`blockTimestamp`: The block Timestamp of the latest block number on L1.
+`highestBlockNumber`: The lastest block number height on L1.
+`lastLiveOfAOwner`: Get the last activities for a given safe owner on L1.
+`intervalLiveness`: the interval (in seconds) from the LivenessModule on L1.
+
+### Execution
+
+To execute with a oneliner:
+
+```bash
+go run ../cmd/monitorism liveness_expiration --safe.address 0xc2819DC788505Aac350142A7A707BF9D03E3Bd03 --l1.node.url https://MySuperRPC --loop.interval.msec 12000 --livenessmodule.address 0x0454092516c9A4d636d3CAfA1e82161376C8a748 --livenessguard.address 0x24424336F04440b1c28685a38303aC33C9D14a25
+```
+
+Otherwise create an env files with the environment variables present into the Help section.
+
+Example:
+
+```bash
+LIVENESS_EXPIRATION_MON_SAFE_ADDRESS=0xc2819DC788505Aac350142A7A707BF9D03E3Bd03
+LIVENESS_EXPIRATION_MON_LIVENESS_MODULE_ADDRESS=0x0454092516c9A4d636d3CAfA1e82161376C8a748
+LIVENESS_EXPIRATION_MON_LIVENESS_GUARD_ADDRESS=0x24424336F04440b1c28685a38303aC33C9D14a25
+```

--- a/op-monitorism/liveness_expiration/README.md
+++ b/op-monitorism/liveness_expiration/README.md
@@ -52,12 +52,14 @@ To execute with a oneliner:
 go run ../cmd/monitorism liveness_expiration --safe.address 0xc2819DC788505Aac350142A7A707BF9D03E3Bd03 --l1.node.url https://MySuperRPC --loop.interval.msec 12000 --livenessmodule.address 0x0454092516c9A4d636d3CAfA1e82161376C8a748 --livenessguard.address 0x24424336F04440b1c28685a38303aC33C9D14a25
 ```
 
-Otherwise create an env files with the environment variables present into the Help section.
+Otherwise create an `.env` file with the environment variables present into the _help section_.
+This is useful to run without any CLI arguments.
 
+````bash
 Example:
 
 ```bash
 LIVENESS_EXPIRATION_MON_SAFE_ADDRESS=0xc2819DC788505Aac350142A7A707BF9D03E3Bd03
 LIVENESS_EXPIRATION_MON_LIVENESS_MODULE_ADDRESS=0x0454092516c9A4d636d3CAfA1e82161376C8a748
 LIVENESS_EXPIRATION_MON_LIVENESS_GUARD_ADDRESS=0x24424336F04440b1c28685a38303aC33C9D14a25
-```
+````

--- a/op-monitorism/liveness_expiration/bindings/GnosisSafe.go
+++ b/op-monitorism/liveness_expiration/bindings/GnosisSafe.go
@@ -1,0 +1,3130 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// GnosisSafeMetaData contains all meta data concerning the GnosisSafe contract.
+var GnosisSafeMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"AddedOwner\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"approvedHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ApproveHash\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"handler\",\"type\":\"address\"}],\"name\":\"ChangedFallbackHandler\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"guard\",\"type\":\"address\"}],\"name\":\"ChangedGuard\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"threshold\",\"type\":\"uint256\"}],\"name\":\"ChangedThreshold\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"DisabledModule\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"EnabledModule\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"txHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"payment\",\"type\":\"uint256\"}],\"name\":\"ExecutionFailure\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"ExecutionFromModuleFailure\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"ExecutionFromModuleSuccess\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"txHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"payment\",\"type\":\"uint256\"}],\"name\":\"ExecutionSuccess\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"RemovedOwner\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"SafeReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"initiator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address[]\",\"name\":\"owners\",\"type\":\"address[]\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"threshold\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"initializer\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"fallbackHandler\",\"type\":\"address\"}],\"name\":\"SafeSetup\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"msgHash\",\"type\":\"bytes32\"}],\"name\":\"SignMsg\",\"type\":\"event\"},{\"stateMutability\":\"nonpayable\",\"type\":\"fallback\"},{\"inputs\":[],\"name\":\"VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_threshold\",\"type\":\"uint256\"}],\"name\":\"addOwnerWithThreshold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashToApprove\",\"type\":\"bytes32\"}],\"name\":\"approveHash\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"approvedHashes\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_threshold\",\"type\":\"uint256\"}],\"name\":\"changeThreshold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"dataHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"requiredSignatures\",\"type\":\"uint256\"}],\"name\":\"checkNSignatures\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"dataHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"}],\"name\":\"checkSignatures\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"prevModule\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"disableModule\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"domainSeparator\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"enableModule\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"safeTxGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"baseGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPrice\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"gasToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"refundReceiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_nonce\",\"type\":\"uint256\"}],\"name\":\"encodeTransactionData\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"safeTxGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"baseGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPrice\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"gasToken\",\"type\":\"address\"},{\"internalType\":\"addresspayable\",\"name\":\"refundReceiver\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"signatures\",\"type\":\"bytes\"}],\"name\":\"execTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"}],\"name\":\"execTransactionFromModule\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"}],\"name\":\"execTransactionFromModuleReturnData\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"returnData\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getChainId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"start\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"pageSize\",\"type\":\"uint256\"}],\"name\":\"getModulesPaginated\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"array\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"next\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getOwners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"offset\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"getStorageAt\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getThreshold\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"safeTxGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"baseGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPrice\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"gasToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"refundReceiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_nonce\",\"type\":\"uint256\"}],\"name\":\"getTransactionHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"module\",\"type\":\"address\"}],\"name\":\"isModuleEnabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"isOwner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"prevOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_threshold\",\"type\":\"uint256\"}],\"name\":\"removeOwner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"enumEnum.Operation\",\"name\":\"operation\",\"type\":\"uint8\"}],\"name\":\"requiredTxGas\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"handler\",\"type\":\"address\"}],\"name\":\"setFallbackHandler\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"guard\",\"type\":\"address\"}],\"name\":\"setGuard\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"_owners\",\"type\":\"address[]\"},{\"internalType\":\"uint256\",\"name\":\"_threshold\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"fallbackHandler\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"paymentToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"payment\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"paymentReceiver\",\"type\":\"address\"}],\"name\":\"setup\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"signedMessages\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"targetContract\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"calldataPayload\",\"type\":\"bytes\"}],\"name\":\"simulateAndRevert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"prevOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"oldOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"swapOwner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// GnosisSafeABI is the input ABI used to generate the binding from.
+// Deprecated: Use GnosisSafeMetaData.ABI instead.
+var GnosisSafeABI = GnosisSafeMetaData.ABI
+
+// GnosisSafe is an auto generated Go binding around an Ethereum contract.
+type GnosisSafe struct {
+	GnosisSafeCaller     // Read-only binding to the contract
+	GnosisSafeTransactor // Write-only binding to the contract
+	GnosisSafeFilterer   // Log filterer for contract events
+}
+
+// GnosisSafeCaller is an auto generated read-only Go binding around an Ethereum contract.
+type GnosisSafeCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GnosisSafeTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type GnosisSafeTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GnosisSafeFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type GnosisSafeFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GnosisSafeSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type GnosisSafeSession struct {
+	Contract     *GnosisSafe       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// GnosisSafeCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type GnosisSafeCallerSession struct {
+	Contract *GnosisSafeCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// GnosisSafeTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type GnosisSafeTransactorSession struct {
+	Contract     *GnosisSafeTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// GnosisSafeRaw is an auto generated low-level Go binding around an Ethereum contract.
+type GnosisSafeRaw struct {
+	Contract *GnosisSafe // Generic contract binding to access the raw methods on
+}
+
+// GnosisSafeCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type GnosisSafeCallerRaw struct {
+	Contract *GnosisSafeCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// GnosisSafeTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type GnosisSafeTransactorRaw struct {
+	Contract *GnosisSafeTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewGnosisSafe creates a new instance of GnosisSafe, bound to a specific deployed contract.
+func NewGnosisSafe(address common.Address, backend bind.ContractBackend) (*GnosisSafe, error) {
+	contract, err := bindGnosisSafe(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafe{GnosisSafeCaller: GnosisSafeCaller{contract: contract}, GnosisSafeTransactor: GnosisSafeTransactor{contract: contract}, GnosisSafeFilterer: GnosisSafeFilterer{contract: contract}}, nil
+}
+
+// NewGnosisSafeCaller creates a new read-only instance of GnosisSafe, bound to a specific deployed contract.
+func NewGnosisSafeCaller(address common.Address, caller bind.ContractCaller) (*GnosisSafeCaller, error) {
+	contract, err := bindGnosisSafe(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeCaller{contract: contract}, nil
+}
+
+// NewGnosisSafeTransactor creates a new write-only instance of GnosisSafe, bound to a specific deployed contract.
+func NewGnosisSafeTransactor(address common.Address, transactor bind.ContractTransactor) (*GnosisSafeTransactor, error) {
+	contract, err := bindGnosisSafe(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeTransactor{contract: contract}, nil
+}
+
+// NewGnosisSafeFilterer creates a new log filterer instance of GnosisSafe, bound to a specific deployed contract.
+func NewGnosisSafeFilterer(address common.Address, filterer bind.ContractFilterer) (*GnosisSafeFilterer, error) {
+	contract, err := bindGnosisSafe(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeFilterer{contract: contract}, nil
+}
+
+// bindGnosisSafe binds a generic wrapper to an already deployed contract.
+func bindGnosisSafe(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := GnosisSafeMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GnosisSafe *GnosisSafeRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GnosisSafe.Contract.GnosisSafeCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GnosisSafe *GnosisSafeRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.GnosisSafeTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GnosisSafe *GnosisSafeRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.GnosisSafeTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GnosisSafe *GnosisSafeCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GnosisSafe.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GnosisSafe *GnosisSafeTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GnosisSafe *GnosisSafeTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.contract.Transact(opts, method, params...)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_GnosisSafe *GnosisSafeCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_GnosisSafe *GnosisSafeSession) VERSION() (string, error) {
+	return _GnosisSafe.Contract.VERSION(&_GnosisSafe.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_GnosisSafe *GnosisSafeCallerSession) VERSION() (string, error) {
+	return _GnosisSafe.Contract.VERSION(&_GnosisSafe.CallOpts)
+}
+
+// ApprovedHashes is a free data retrieval call binding the contract method 0x7d832974.
+//
+// Solidity: function approvedHashes(address , bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeCaller) ApprovedHashes(opts *bind.CallOpts, arg0 common.Address, arg1 [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "approvedHashes", arg0, arg1)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ApprovedHashes is a free data retrieval call binding the contract method 0x7d832974.
+//
+// Solidity: function approvedHashes(address , bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) ApprovedHashes(arg0 common.Address, arg1 [32]byte) (*big.Int, error) {
+	return _GnosisSafe.Contract.ApprovedHashes(&_GnosisSafe.CallOpts, arg0, arg1)
+}
+
+// ApprovedHashes is a free data retrieval call binding the contract method 0x7d832974.
+//
+// Solidity: function approvedHashes(address , bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeCallerSession) ApprovedHashes(arg0 common.Address, arg1 [32]byte) (*big.Int, error) {
+	return _GnosisSafe.Contract.ApprovedHashes(&_GnosisSafe.CallOpts, arg0, arg1)
+}
+
+// CheckNSignatures is a free data retrieval call binding the contract method 0x12fb68e0.
+//
+// Solidity: function checkNSignatures(bytes32 dataHash, bytes data, bytes signatures, uint256 requiredSignatures) view returns()
+func (_GnosisSafe *GnosisSafeCaller) CheckNSignatures(opts *bind.CallOpts, dataHash [32]byte, data []byte, signatures []byte, requiredSignatures *big.Int) error {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "checkNSignatures", dataHash, data, signatures, requiredSignatures)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// CheckNSignatures is a free data retrieval call binding the contract method 0x12fb68e0.
+//
+// Solidity: function checkNSignatures(bytes32 dataHash, bytes data, bytes signatures, uint256 requiredSignatures) view returns()
+func (_GnosisSafe *GnosisSafeSession) CheckNSignatures(dataHash [32]byte, data []byte, signatures []byte, requiredSignatures *big.Int) error {
+	return _GnosisSafe.Contract.CheckNSignatures(&_GnosisSafe.CallOpts, dataHash, data, signatures, requiredSignatures)
+}
+
+// CheckNSignatures is a free data retrieval call binding the contract method 0x12fb68e0.
+//
+// Solidity: function checkNSignatures(bytes32 dataHash, bytes data, bytes signatures, uint256 requiredSignatures) view returns()
+func (_GnosisSafe *GnosisSafeCallerSession) CheckNSignatures(dataHash [32]byte, data []byte, signatures []byte, requiredSignatures *big.Int) error {
+	return _GnosisSafe.Contract.CheckNSignatures(&_GnosisSafe.CallOpts, dataHash, data, signatures, requiredSignatures)
+}
+
+// CheckSignatures is a free data retrieval call binding the contract method 0x934f3a11.
+//
+// Solidity: function checkSignatures(bytes32 dataHash, bytes data, bytes signatures) view returns()
+func (_GnosisSafe *GnosisSafeCaller) CheckSignatures(opts *bind.CallOpts, dataHash [32]byte, data []byte, signatures []byte) error {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "checkSignatures", dataHash, data, signatures)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// CheckSignatures is a free data retrieval call binding the contract method 0x934f3a11.
+//
+// Solidity: function checkSignatures(bytes32 dataHash, bytes data, bytes signatures) view returns()
+func (_GnosisSafe *GnosisSafeSession) CheckSignatures(dataHash [32]byte, data []byte, signatures []byte) error {
+	return _GnosisSafe.Contract.CheckSignatures(&_GnosisSafe.CallOpts, dataHash, data, signatures)
+}
+
+// CheckSignatures is a free data retrieval call binding the contract method 0x934f3a11.
+//
+// Solidity: function checkSignatures(bytes32 dataHash, bytes data, bytes signatures) view returns()
+func (_GnosisSafe *GnosisSafeCallerSession) CheckSignatures(dataHash [32]byte, data []byte, signatures []byte) error {
+	return _GnosisSafe.Contract.CheckSignatures(&_GnosisSafe.CallOpts, dataHash, data, signatures)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_GnosisSafe *GnosisSafeCaller) DomainSeparator(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "domainSeparator")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_GnosisSafe *GnosisSafeSession) DomainSeparator() ([32]byte, error) {
+	return _GnosisSafe.Contract.DomainSeparator(&_GnosisSafe.CallOpts)
+}
+
+// DomainSeparator is a free data retrieval call binding the contract method 0xf698da25.
+//
+// Solidity: function domainSeparator() view returns(bytes32)
+func (_GnosisSafe *GnosisSafeCallerSession) DomainSeparator() ([32]byte, error) {
+	return _GnosisSafe.Contract.DomainSeparator(&_GnosisSafe.CallOpts)
+}
+
+// EncodeTransactionData is a free data retrieval call binding the contract method 0xe86637db.
+//
+// Solidity: function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes)
+func (_GnosisSafe *GnosisSafeCaller) EncodeTransactionData(opts *bind.CallOpts, to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([]byte, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "encodeTransactionData", to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// EncodeTransactionData is a free data retrieval call binding the contract method 0xe86637db.
+//
+// Solidity: function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes)
+func (_GnosisSafe *GnosisSafeSession) EncodeTransactionData(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([]byte, error) {
+	return _GnosisSafe.Contract.EncodeTransactionData(&_GnosisSafe.CallOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+}
+
+// EncodeTransactionData is a free data retrieval call binding the contract method 0xe86637db.
+//
+// Solidity: function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes)
+func (_GnosisSafe *GnosisSafeCallerSession) EncodeTransactionData(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([]byte, error) {
+	return _GnosisSafe.Contract.EncodeTransactionData(&_GnosisSafe.CallOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+}
+
+// GetChainId is a free data retrieval call binding the contract method 0x3408e470.
+//
+// Solidity: function getChainId() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCaller) GetChainId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getChainId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetChainId is a free data retrieval call binding the contract method 0x3408e470.
+//
+// Solidity: function getChainId() view returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) GetChainId() (*big.Int, error) {
+	return _GnosisSafe.Contract.GetChainId(&_GnosisSafe.CallOpts)
+}
+
+// GetChainId is a free data retrieval call binding the contract method 0x3408e470.
+//
+// Solidity: function getChainId() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCallerSession) GetChainId() (*big.Int, error) {
+	return _GnosisSafe.Contract.GetChainId(&_GnosisSafe.CallOpts)
+}
+
+// GetModulesPaginated is a free data retrieval call binding the contract method 0xcc2f8452.
+//
+// Solidity: function getModulesPaginated(address start, uint256 pageSize) view returns(address[] array, address next)
+func (_GnosisSafe *GnosisSafeCaller) GetModulesPaginated(opts *bind.CallOpts, start common.Address, pageSize *big.Int) (struct {
+	Array []common.Address
+	Next  common.Address
+}, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getModulesPaginated", start, pageSize)
+
+	outstruct := new(struct {
+		Array []common.Address
+		Next  common.Address
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Array = *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+	outstruct.Next = *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+
+	return *outstruct, err
+
+}
+
+// GetModulesPaginated is a free data retrieval call binding the contract method 0xcc2f8452.
+//
+// Solidity: function getModulesPaginated(address start, uint256 pageSize) view returns(address[] array, address next)
+func (_GnosisSafe *GnosisSafeSession) GetModulesPaginated(start common.Address, pageSize *big.Int) (struct {
+	Array []common.Address
+	Next  common.Address
+}, error) {
+	return _GnosisSafe.Contract.GetModulesPaginated(&_GnosisSafe.CallOpts, start, pageSize)
+}
+
+// GetModulesPaginated is a free data retrieval call binding the contract method 0xcc2f8452.
+//
+// Solidity: function getModulesPaginated(address start, uint256 pageSize) view returns(address[] array, address next)
+func (_GnosisSafe *GnosisSafeCallerSession) GetModulesPaginated(start common.Address, pageSize *big.Int) (struct {
+	Array []common.Address
+	Next  common.Address
+}, error) {
+	return _GnosisSafe.Contract.GetModulesPaginated(&_GnosisSafe.CallOpts, start, pageSize)
+}
+
+// GetOwners is a free data retrieval call binding the contract method 0xa0e67e2b.
+//
+// Solidity: function getOwners() view returns(address[])
+func (_GnosisSafe *GnosisSafeCaller) GetOwners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getOwners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// GetOwners is a free data retrieval call binding the contract method 0xa0e67e2b.
+//
+// Solidity: function getOwners() view returns(address[])
+func (_GnosisSafe *GnosisSafeSession) GetOwners() ([]common.Address, error) {
+	return _GnosisSafe.Contract.GetOwners(&_GnosisSafe.CallOpts)
+}
+
+// GetOwners is a free data retrieval call binding the contract method 0xa0e67e2b.
+//
+// Solidity: function getOwners() view returns(address[])
+func (_GnosisSafe *GnosisSafeCallerSession) GetOwners() ([]common.Address, error) {
+	return _GnosisSafe.Contract.GetOwners(&_GnosisSafe.CallOpts)
+}
+
+// GetStorageAt is a free data retrieval call binding the contract method 0x5624b25b.
+//
+// Solidity: function getStorageAt(uint256 offset, uint256 length) view returns(bytes)
+func (_GnosisSafe *GnosisSafeCaller) GetStorageAt(opts *bind.CallOpts, offset *big.Int, length *big.Int) ([]byte, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getStorageAt", offset, length)
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// GetStorageAt is a free data retrieval call binding the contract method 0x5624b25b.
+//
+// Solidity: function getStorageAt(uint256 offset, uint256 length) view returns(bytes)
+func (_GnosisSafe *GnosisSafeSession) GetStorageAt(offset *big.Int, length *big.Int) ([]byte, error) {
+	return _GnosisSafe.Contract.GetStorageAt(&_GnosisSafe.CallOpts, offset, length)
+}
+
+// GetStorageAt is a free data retrieval call binding the contract method 0x5624b25b.
+//
+// Solidity: function getStorageAt(uint256 offset, uint256 length) view returns(bytes)
+func (_GnosisSafe *GnosisSafeCallerSession) GetStorageAt(offset *big.Int, length *big.Int) ([]byte, error) {
+	return _GnosisSafe.Contract.GetStorageAt(&_GnosisSafe.CallOpts, offset, length)
+}
+
+// GetThreshold is a free data retrieval call binding the contract method 0xe75235b8.
+//
+// Solidity: function getThreshold() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCaller) GetThreshold(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getThreshold")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetThreshold is a free data retrieval call binding the contract method 0xe75235b8.
+//
+// Solidity: function getThreshold() view returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) GetThreshold() (*big.Int, error) {
+	return _GnosisSafe.Contract.GetThreshold(&_GnosisSafe.CallOpts)
+}
+
+// GetThreshold is a free data retrieval call binding the contract method 0xe75235b8.
+//
+// Solidity: function getThreshold() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCallerSession) GetThreshold() (*big.Int, error) {
+	return _GnosisSafe.Contract.GetThreshold(&_GnosisSafe.CallOpts)
+}
+
+// GetTransactionHash is a free data retrieval call binding the contract method 0xd8d11f78.
+//
+// Solidity: function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes32)
+func (_GnosisSafe *GnosisSafeCaller) GetTransactionHash(opts *bind.CallOpts, to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "getTransactionHash", to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetTransactionHash is a free data retrieval call binding the contract method 0xd8d11f78.
+//
+// Solidity: function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes32)
+func (_GnosisSafe *GnosisSafeSession) GetTransactionHash(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([32]byte, error) {
+	return _GnosisSafe.Contract.GetTransactionHash(&_GnosisSafe.CallOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+}
+
+// GetTransactionHash is a free data retrieval call binding the contract method 0xd8d11f78.
+//
+// Solidity: function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns(bytes32)
+func (_GnosisSafe *GnosisSafeCallerSession) GetTransactionHash(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, _nonce *big.Int) ([32]byte, error) {
+	return _GnosisSafe.Contract.GetTransactionHash(&_GnosisSafe.CallOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce)
+}
+
+// IsModuleEnabled is a free data retrieval call binding the contract method 0x2d9ad53d.
+//
+// Solidity: function isModuleEnabled(address module) view returns(bool)
+func (_GnosisSafe *GnosisSafeCaller) IsModuleEnabled(opts *bind.CallOpts, module common.Address) (bool, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "isModuleEnabled", module)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleEnabled is a free data retrieval call binding the contract method 0x2d9ad53d.
+//
+// Solidity: function isModuleEnabled(address module) view returns(bool)
+func (_GnosisSafe *GnosisSafeSession) IsModuleEnabled(module common.Address) (bool, error) {
+	return _GnosisSafe.Contract.IsModuleEnabled(&_GnosisSafe.CallOpts, module)
+}
+
+// IsModuleEnabled is a free data retrieval call binding the contract method 0x2d9ad53d.
+//
+// Solidity: function isModuleEnabled(address module) view returns(bool)
+func (_GnosisSafe *GnosisSafeCallerSession) IsModuleEnabled(module common.Address) (bool, error) {
+	return _GnosisSafe.Contract.IsModuleEnabled(&_GnosisSafe.CallOpts, module)
+}
+
+// IsOwner is a free data retrieval call binding the contract method 0x2f54bf6e.
+//
+// Solidity: function isOwner(address owner) view returns(bool)
+func (_GnosisSafe *GnosisSafeCaller) IsOwner(opts *bind.CallOpts, owner common.Address) (bool, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "isOwner", owner)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOwner is a free data retrieval call binding the contract method 0x2f54bf6e.
+//
+// Solidity: function isOwner(address owner) view returns(bool)
+func (_GnosisSafe *GnosisSafeSession) IsOwner(owner common.Address) (bool, error) {
+	return _GnosisSafe.Contract.IsOwner(&_GnosisSafe.CallOpts, owner)
+}
+
+// IsOwner is a free data retrieval call binding the contract method 0x2f54bf6e.
+//
+// Solidity: function isOwner(address owner) view returns(bool)
+func (_GnosisSafe *GnosisSafeCallerSession) IsOwner(owner common.Address) (bool, error) {
+	return _GnosisSafe.Contract.IsOwner(&_GnosisSafe.CallOpts, owner)
+}
+
+// Nonce is a free data retrieval call binding the contract method 0xaffed0e0.
+//
+// Solidity: function nonce() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCaller) Nonce(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "nonce")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Nonce is a free data retrieval call binding the contract method 0xaffed0e0.
+//
+// Solidity: function nonce() view returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) Nonce() (*big.Int, error) {
+	return _GnosisSafe.Contract.Nonce(&_GnosisSafe.CallOpts)
+}
+
+// Nonce is a free data retrieval call binding the contract method 0xaffed0e0.
+//
+// Solidity: function nonce() view returns(uint256)
+func (_GnosisSafe *GnosisSafeCallerSession) Nonce() (*big.Int, error) {
+	return _GnosisSafe.Contract.Nonce(&_GnosisSafe.CallOpts)
+}
+
+// SignedMessages is a free data retrieval call binding the contract method 0x5ae6bd37.
+//
+// Solidity: function signedMessages(bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeCaller) SignedMessages(opts *bind.CallOpts, arg0 [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _GnosisSafe.contract.Call(opts, &out, "signedMessages", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SignedMessages is a free data retrieval call binding the contract method 0x5ae6bd37.
+//
+// Solidity: function signedMessages(bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) SignedMessages(arg0 [32]byte) (*big.Int, error) {
+	return _GnosisSafe.Contract.SignedMessages(&_GnosisSafe.CallOpts, arg0)
+}
+
+// SignedMessages is a free data retrieval call binding the contract method 0x5ae6bd37.
+//
+// Solidity: function signedMessages(bytes32 ) view returns(uint256)
+func (_GnosisSafe *GnosisSafeCallerSession) SignedMessages(arg0 [32]byte) (*big.Int, error) {
+	return _GnosisSafe.Contract.SignedMessages(&_GnosisSafe.CallOpts, arg0)
+}
+
+// AddOwnerWithThreshold is a paid mutator transaction binding the contract method 0x0d582f13.
+//
+// Solidity: function addOwnerWithThreshold(address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactor) AddOwnerWithThreshold(opts *bind.TransactOpts, owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "addOwnerWithThreshold", owner, _threshold)
+}
+
+// AddOwnerWithThreshold is a paid mutator transaction binding the contract method 0x0d582f13.
+//
+// Solidity: function addOwnerWithThreshold(address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeSession) AddOwnerWithThreshold(owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.AddOwnerWithThreshold(&_GnosisSafe.TransactOpts, owner, _threshold)
+}
+
+// AddOwnerWithThreshold is a paid mutator transaction binding the contract method 0x0d582f13.
+//
+// Solidity: function addOwnerWithThreshold(address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) AddOwnerWithThreshold(owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.AddOwnerWithThreshold(&_GnosisSafe.TransactOpts, owner, _threshold)
+}
+
+// ApproveHash is a paid mutator transaction binding the contract method 0xd4d9bdcd.
+//
+// Solidity: function approveHash(bytes32 hashToApprove) returns()
+func (_GnosisSafe *GnosisSafeTransactor) ApproveHash(opts *bind.TransactOpts, hashToApprove [32]byte) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "approveHash", hashToApprove)
+}
+
+// ApproveHash is a paid mutator transaction binding the contract method 0xd4d9bdcd.
+//
+// Solidity: function approveHash(bytes32 hashToApprove) returns()
+func (_GnosisSafe *GnosisSafeSession) ApproveHash(hashToApprove [32]byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ApproveHash(&_GnosisSafe.TransactOpts, hashToApprove)
+}
+
+// ApproveHash is a paid mutator transaction binding the contract method 0xd4d9bdcd.
+//
+// Solidity: function approveHash(bytes32 hashToApprove) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) ApproveHash(hashToApprove [32]byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ApproveHash(&_GnosisSafe.TransactOpts, hashToApprove)
+}
+
+// ChangeThreshold is a paid mutator transaction binding the contract method 0x694e80c3.
+//
+// Solidity: function changeThreshold(uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactor) ChangeThreshold(opts *bind.TransactOpts, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "changeThreshold", _threshold)
+}
+
+// ChangeThreshold is a paid mutator transaction binding the contract method 0x694e80c3.
+//
+// Solidity: function changeThreshold(uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeSession) ChangeThreshold(_threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ChangeThreshold(&_GnosisSafe.TransactOpts, _threshold)
+}
+
+// ChangeThreshold is a paid mutator transaction binding the contract method 0x694e80c3.
+//
+// Solidity: function changeThreshold(uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) ChangeThreshold(_threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ChangeThreshold(&_GnosisSafe.TransactOpts, _threshold)
+}
+
+// DisableModule is a paid mutator transaction binding the contract method 0xe009cfde.
+//
+// Solidity: function disableModule(address prevModule, address module) returns()
+func (_GnosisSafe *GnosisSafeTransactor) DisableModule(opts *bind.TransactOpts, prevModule common.Address, module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "disableModule", prevModule, module)
+}
+
+// DisableModule is a paid mutator transaction binding the contract method 0xe009cfde.
+//
+// Solidity: function disableModule(address prevModule, address module) returns()
+func (_GnosisSafe *GnosisSafeSession) DisableModule(prevModule common.Address, module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.DisableModule(&_GnosisSafe.TransactOpts, prevModule, module)
+}
+
+// DisableModule is a paid mutator transaction binding the contract method 0xe009cfde.
+//
+// Solidity: function disableModule(address prevModule, address module) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) DisableModule(prevModule common.Address, module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.DisableModule(&_GnosisSafe.TransactOpts, prevModule, module)
+}
+
+// EnableModule is a paid mutator transaction binding the contract method 0x610b5925.
+//
+// Solidity: function enableModule(address module) returns()
+func (_GnosisSafe *GnosisSafeTransactor) EnableModule(opts *bind.TransactOpts, module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "enableModule", module)
+}
+
+// EnableModule is a paid mutator transaction binding the contract method 0x610b5925.
+//
+// Solidity: function enableModule(address module) returns()
+func (_GnosisSafe *GnosisSafeSession) EnableModule(module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.EnableModule(&_GnosisSafe.TransactOpts, module)
+}
+
+// EnableModule is a paid mutator transaction binding the contract method 0x610b5925.
+//
+// Solidity: function enableModule(address module) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) EnableModule(module common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.EnableModule(&_GnosisSafe.TransactOpts, module)
+}
+
+// ExecTransaction is a paid mutator transaction binding the contract method 0x6a761202.
+//
+// Solidity: function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns(bool success)
+func (_GnosisSafe *GnosisSafeTransactor) ExecTransaction(opts *bind.TransactOpts, to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "execTransaction", to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures)
+}
+
+// ExecTransaction is a paid mutator transaction binding the contract method 0x6a761202.
+//
+// Solidity: function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns(bool success)
+func (_GnosisSafe *GnosisSafeSession) ExecTransaction(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransaction(&_GnosisSafe.TransactOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures)
+}
+
+// ExecTransaction is a paid mutator transaction binding the contract method 0x6a761202.
+//
+// Solidity: function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns(bool success)
+func (_GnosisSafe *GnosisSafeTransactorSession) ExecTransaction(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransaction(&_GnosisSafe.TransactOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures)
+}
+
+// ExecTransactionFromModule is a paid mutator transaction binding the contract method 0x468721a7.
+//
+// Solidity: function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns(bool success)
+func (_GnosisSafe *GnosisSafeTransactor) ExecTransactionFromModule(opts *bind.TransactOpts, to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "execTransactionFromModule", to, value, data, operation)
+}
+
+// ExecTransactionFromModule is a paid mutator transaction binding the contract method 0x468721a7.
+//
+// Solidity: function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns(bool success)
+func (_GnosisSafe *GnosisSafeSession) ExecTransactionFromModule(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransactionFromModule(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// ExecTransactionFromModule is a paid mutator transaction binding the contract method 0x468721a7.
+//
+// Solidity: function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns(bool success)
+func (_GnosisSafe *GnosisSafeTransactorSession) ExecTransactionFromModule(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransactionFromModule(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// ExecTransactionFromModuleReturnData is a paid mutator transaction binding the contract method 0x5229073f.
+//
+// Solidity: function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns(bool success, bytes returnData)
+func (_GnosisSafe *GnosisSafeTransactor) ExecTransactionFromModuleReturnData(opts *bind.TransactOpts, to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "execTransactionFromModuleReturnData", to, value, data, operation)
+}
+
+// ExecTransactionFromModuleReturnData is a paid mutator transaction binding the contract method 0x5229073f.
+//
+// Solidity: function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns(bool success, bytes returnData)
+func (_GnosisSafe *GnosisSafeSession) ExecTransactionFromModuleReturnData(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransactionFromModuleReturnData(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// ExecTransactionFromModuleReturnData is a paid mutator transaction binding the contract method 0x5229073f.
+//
+// Solidity: function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns(bool success, bytes returnData)
+func (_GnosisSafe *GnosisSafeTransactorSession) ExecTransactionFromModuleReturnData(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.ExecTransactionFromModuleReturnData(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// RemoveOwner is a paid mutator transaction binding the contract method 0xf8dc5dd9.
+//
+// Solidity: function removeOwner(address prevOwner, address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactor) RemoveOwner(opts *bind.TransactOpts, prevOwner common.Address, owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "removeOwner", prevOwner, owner, _threshold)
+}
+
+// RemoveOwner is a paid mutator transaction binding the contract method 0xf8dc5dd9.
+//
+// Solidity: function removeOwner(address prevOwner, address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeSession) RemoveOwner(prevOwner common.Address, owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.RemoveOwner(&_GnosisSafe.TransactOpts, prevOwner, owner, _threshold)
+}
+
+// RemoveOwner is a paid mutator transaction binding the contract method 0xf8dc5dd9.
+//
+// Solidity: function removeOwner(address prevOwner, address owner, uint256 _threshold) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) RemoveOwner(prevOwner common.Address, owner common.Address, _threshold *big.Int) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.RemoveOwner(&_GnosisSafe.TransactOpts, prevOwner, owner, _threshold)
+}
+
+// RequiredTxGas is a paid mutator transaction binding the contract method 0xc4ca3a9c.
+//
+// Solidity: function requiredTxGas(address to, uint256 value, bytes data, uint8 operation) returns(uint256)
+func (_GnosisSafe *GnosisSafeTransactor) RequiredTxGas(opts *bind.TransactOpts, to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "requiredTxGas", to, value, data, operation)
+}
+
+// RequiredTxGas is a paid mutator transaction binding the contract method 0xc4ca3a9c.
+//
+// Solidity: function requiredTxGas(address to, uint256 value, bytes data, uint8 operation) returns(uint256)
+func (_GnosisSafe *GnosisSafeSession) RequiredTxGas(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.RequiredTxGas(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// RequiredTxGas is a paid mutator transaction binding the contract method 0xc4ca3a9c.
+//
+// Solidity: function requiredTxGas(address to, uint256 value, bytes data, uint8 operation) returns(uint256)
+func (_GnosisSafe *GnosisSafeTransactorSession) RequiredTxGas(to common.Address, value *big.Int, data []byte, operation uint8) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.RequiredTxGas(&_GnosisSafe.TransactOpts, to, value, data, operation)
+}
+
+// SetFallbackHandler is a paid mutator transaction binding the contract method 0xf08a0323.
+//
+// Solidity: function setFallbackHandler(address handler) returns()
+func (_GnosisSafe *GnosisSafeTransactor) SetFallbackHandler(opts *bind.TransactOpts, handler common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "setFallbackHandler", handler)
+}
+
+// SetFallbackHandler is a paid mutator transaction binding the contract method 0xf08a0323.
+//
+// Solidity: function setFallbackHandler(address handler) returns()
+func (_GnosisSafe *GnosisSafeSession) SetFallbackHandler(handler common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SetFallbackHandler(&_GnosisSafe.TransactOpts, handler)
+}
+
+// SetFallbackHandler is a paid mutator transaction binding the contract method 0xf08a0323.
+//
+// Solidity: function setFallbackHandler(address handler) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) SetFallbackHandler(handler common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SetFallbackHandler(&_GnosisSafe.TransactOpts, handler)
+}
+
+// SetGuard is a paid mutator transaction binding the contract method 0xe19a9dd9.
+//
+// Solidity: function setGuard(address guard) returns()
+func (_GnosisSafe *GnosisSafeTransactor) SetGuard(opts *bind.TransactOpts, guard common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "setGuard", guard)
+}
+
+// SetGuard is a paid mutator transaction binding the contract method 0xe19a9dd9.
+//
+// Solidity: function setGuard(address guard) returns()
+func (_GnosisSafe *GnosisSafeSession) SetGuard(guard common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SetGuard(&_GnosisSafe.TransactOpts, guard)
+}
+
+// SetGuard is a paid mutator transaction binding the contract method 0xe19a9dd9.
+//
+// Solidity: function setGuard(address guard) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) SetGuard(guard common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SetGuard(&_GnosisSafe.TransactOpts, guard)
+}
+
+// Setup is a paid mutator transaction binding the contract method 0xb63e800d.
+//
+// Solidity: function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver) returns()
+func (_GnosisSafe *GnosisSafeTransactor) Setup(opts *bind.TransactOpts, _owners []common.Address, _threshold *big.Int, to common.Address, data []byte, fallbackHandler common.Address, paymentToken common.Address, payment *big.Int, paymentReceiver common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "setup", _owners, _threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver)
+}
+
+// Setup is a paid mutator transaction binding the contract method 0xb63e800d.
+//
+// Solidity: function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver) returns()
+func (_GnosisSafe *GnosisSafeSession) Setup(_owners []common.Address, _threshold *big.Int, to common.Address, data []byte, fallbackHandler common.Address, paymentToken common.Address, payment *big.Int, paymentReceiver common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Setup(&_GnosisSafe.TransactOpts, _owners, _threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver)
+}
+
+// Setup is a paid mutator transaction binding the contract method 0xb63e800d.
+//
+// Solidity: function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) Setup(_owners []common.Address, _threshold *big.Int, to common.Address, data []byte, fallbackHandler common.Address, paymentToken common.Address, payment *big.Int, paymentReceiver common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Setup(&_GnosisSafe.TransactOpts, _owners, _threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver)
+}
+
+// SimulateAndRevert is a paid mutator transaction binding the contract method 0xb4faba09.
+//
+// Solidity: function simulateAndRevert(address targetContract, bytes calldataPayload) returns()
+func (_GnosisSafe *GnosisSafeTransactor) SimulateAndRevert(opts *bind.TransactOpts, targetContract common.Address, calldataPayload []byte) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "simulateAndRevert", targetContract, calldataPayload)
+}
+
+// SimulateAndRevert is a paid mutator transaction binding the contract method 0xb4faba09.
+//
+// Solidity: function simulateAndRevert(address targetContract, bytes calldataPayload) returns()
+func (_GnosisSafe *GnosisSafeSession) SimulateAndRevert(targetContract common.Address, calldataPayload []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SimulateAndRevert(&_GnosisSafe.TransactOpts, targetContract, calldataPayload)
+}
+
+// SimulateAndRevert is a paid mutator transaction binding the contract method 0xb4faba09.
+//
+// Solidity: function simulateAndRevert(address targetContract, bytes calldataPayload) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) SimulateAndRevert(targetContract common.Address, calldataPayload []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SimulateAndRevert(&_GnosisSafe.TransactOpts, targetContract, calldataPayload)
+}
+
+// SwapOwner is a paid mutator transaction binding the contract method 0xe318b52b.
+//
+// Solidity: function swapOwner(address prevOwner, address oldOwner, address newOwner) returns()
+func (_GnosisSafe *GnosisSafeTransactor) SwapOwner(opts *bind.TransactOpts, prevOwner common.Address, oldOwner common.Address, newOwner common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.contract.Transact(opts, "swapOwner", prevOwner, oldOwner, newOwner)
+}
+
+// SwapOwner is a paid mutator transaction binding the contract method 0xe318b52b.
+//
+// Solidity: function swapOwner(address prevOwner, address oldOwner, address newOwner) returns()
+func (_GnosisSafe *GnosisSafeSession) SwapOwner(prevOwner common.Address, oldOwner common.Address, newOwner common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SwapOwner(&_GnosisSafe.TransactOpts, prevOwner, oldOwner, newOwner)
+}
+
+// SwapOwner is a paid mutator transaction binding the contract method 0xe318b52b.
+//
+// Solidity: function swapOwner(address prevOwner, address oldOwner, address newOwner) returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) SwapOwner(prevOwner common.Address, oldOwner common.Address, newOwner common.Address) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.SwapOwner(&_GnosisSafe.TransactOpts, prevOwner, oldOwner, newOwner)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_GnosisSafe *GnosisSafeTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _GnosisSafe.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_GnosisSafe *GnosisSafeSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Fallback(&_GnosisSafe.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Fallback(&_GnosisSafe.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_GnosisSafe *GnosisSafeTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GnosisSafe.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_GnosisSafe *GnosisSafeSession) Receive() (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Receive(&_GnosisSafe.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_GnosisSafe *GnosisSafeTransactorSession) Receive() (*types.Transaction, error) {
+	return _GnosisSafe.Contract.Receive(&_GnosisSafe.TransactOpts)
+}
+
+// GnosisSafeAddedOwnerIterator is returned from FilterAddedOwner and is used to iterate over the raw logs and unpacked data for AddedOwner events raised by the GnosisSafe contract.
+type GnosisSafeAddedOwnerIterator struct {
+	Event *GnosisSafeAddedOwner // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeAddedOwnerIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeAddedOwner)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeAddedOwner)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeAddedOwnerIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeAddedOwnerIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeAddedOwner represents a AddedOwner event raised by the GnosisSafe contract.
+type GnosisSafeAddedOwner struct {
+	Owner common.Address
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterAddedOwner is a free log retrieval operation binding the contract event 0x9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26.
+//
+// Solidity: event AddedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) FilterAddedOwner(opts *bind.FilterOpts) (*GnosisSafeAddedOwnerIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "AddedOwner")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeAddedOwnerIterator{contract: _GnosisSafe.contract, event: "AddedOwner", logs: logs, sub: sub}, nil
+}
+
+// WatchAddedOwner is a free log subscription operation binding the contract event 0x9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26.
+//
+// Solidity: event AddedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) WatchAddedOwner(opts *bind.WatchOpts, sink chan<- *GnosisSafeAddedOwner) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "AddedOwner")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeAddedOwner)
+				if err := _GnosisSafe.contract.UnpackLog(event, "AddedOwner", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAddedOwner is a log parse operation binding the contract event 0x9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26.
+//
+// Solidity: event AddedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) ParseAddedOwner(log types.Log) (*GnosisSafeAddedOwner, error) {
+	event := new(GnosisSafeAddedOwner)
+	if err := _GnosisSafe.contract.UnpackLog(event, "AddedOwner", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeApproveHashIterator is returned from FilterApproveHash and is used to iterate over the raw logs and unpacked data for ApproveHash events raised by the GnosisSafe contract.
+type GnosisSafeApproveHashIterator struct {
+	Event *GnosisSafeApproveHash // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeApproveHashIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeApproveHash)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeApproveHash)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeApproveHashIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeApproveHashIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeApproveHash represents a ApproveHash event raised by the GnosisSafe contract.
+type GnosisSafeApproveHash struct {
+	ApprovedHash [32]byte
+	Owner        common.Address
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterApproveHash is a free log retrieval operation binding the contract event 0xf2a0eb156472d1440255b0d7c1e19cc07115d1051fe605b0dce69acfec884d9c.
+//
+// Solidity: event ApproveHash(bytes32 indexed approvedHash, address indexed owner)
+func (_GnosisSafe *GnosisSafeFilterer) FilterApproveHash(opts *bind.FilterOpts, approvedHash [][32]byte, owner []common.Address) (*GnosisSafeApproveHashIterator, error) {
+
+	var approvedHashRule []interface{}
+	for _, approvedHashItem := range approvedHash {
+		approvedHashRule = append(approvedHashRule, approvedHashItem)
+	}
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ApproveHash", approvedHashRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeApproveHashIterator{contract: _GnosisSafe.contract, event: "ApproveHash", logs: logs, sub: sub}, nil
+}
+
+// WatchApproveHash is a free log subscription operation binding the contract event 0xf2a0eb156472d1440255b0d7c1e19cc07115d1051fe605b0dce69acfec884d9c.
+//
+// Solidity: event ApproveHash(bytes32 indexed approvedHash, address indexed owner)
+func (_GnosisSafe *GnosisSafeFilterer) WatchApproveHash(opts *bind.WatchOpts, sink chan<- *GnosisSafeApproveHash, approvedHash [][32]byte, owner []common.Address) (event.Subscription, error) {
+
+	var approvedHashRule []interface{}
+	for _, approvedHashItem := range approvedHash {
+		approvedHashRule = append(approvedHashRule, approvedHashItem)
+	}
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ApproveHash", approvedHashRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeApproveHash)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ApproveHash", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApproveHash is a log parse operation binding the contract event 0xf2a0eb156472d1440255b0d7c1e19cc07115d1051fe605b0dce69acfec884d9c.
+//
+// Solidity: event ApproveHash(bytes32 indexed approvedHash, address indexed owner)
+func (_GnosisSafe *GnosisSafeFilterer) ParseApproveHash(log types.Log) (*GnosisSafeApproveHash, error) {
+	event := new(GnosisSafeApproveHash)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ApproveHash", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeChangedFallbackHandlerIterator is returned from FilterChangedFallbackHandler and is used to iterate over the raw logs and unpacked data for ChangedFallbackHandler events raised by the GnosisSafe contract.
+type GnosisSafeChangedFallbackHandlerIterator struct {
+	Event *GnosisSafeChangedFallbackHandler // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeChangedFallbackHandlerIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeChangedFallbackHandler)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeChangedFallbackHandler)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeChangedFallbackHandlerIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeChangedFallbackHandlerIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeChangedFallbackHandler represents a ChangedFallbackHandler event raised by the GnosisSafe contract.
+type GnosisSafeChangedFallbackHandler struct {
+	Handler common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterChangedFallbackHandler is a free log retrieval operation binding the contract event 0x5ac6c46c93c8d0e53714ba3b53db3e7c046da994313d7ed0d192028bc7c228b0.
+//
+// Solidity: event ChangedFallbackHandler(address handler)
+func (_GnosisSafe *GnosisSafeFilterer) FilterChangedFallbackHandler(opts *bind.FilterOpts) (*GnosisSafeChangedFallbackHandlerIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ChangedFallbackHandler")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeChangedFallbackHandlerIterator{contract: _GnosisSafe.contract, event: "ChangedFallbackHandler", logs: logs, sub: sub}, nil
+}
+
+// WatchChangedFallbackHandler is a free log subscription operation binding the contract event 0x5ac6c46c93c8d0e53714ba3b53db3e7c046da994313d7ed0d192028bc7c228b0.
+//
+// Solidity: event ChangedFallbackHandler(address handler)
+func (_GnosisSafe *GnosisSafeFilterer) WatchChangedFallbackHandler(opts *bind.WatchOpts, sink chan<- *GnosisSafeChangedFallbackHandler) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ChangedFallbackHandler")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeChangedFallbackHandler)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ChangedFallbackHandler", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseChangedFallbackHandler is a log parse operation binding the contract event 0x5ac6c46c93c8d0e53714ba3b53db3e7c046da994313d7ed0d192028bc7c228b0.
+//
+// Solidity: event ChangedFallbackHandler(address handler)
+func (_GnosisSafe *GnosisSafeFilterer) ParseChangedFallbackHandler(log types.Log) (*GnosisSafeChangedFallbackHandler, error) {
+	event := new(GnosisSafeChangedFallbackHandler)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ChangedFallbackHandler", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeChangedGuardIterator is returned from FilterChangedGuard and is used to iterate over the raw logs and unpacked data for ChangedGuard events raised by the GnosisSafe contract.
+type GnosisSafeChangedGuardIterator struct {
+	Event *GnosisSafeChangedGuard // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeChangedGuardIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeChangedGuard)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeChangedGuard)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeChangedGuardIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeChangedGuardIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeChangedGuard represents a ChangedGuard event raised by the GnosisSafe contract.
+type GnosisSafeChangedGuard struct {
+	Guard common.Address
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterChangedGuard is a free log retrieval operation binding the contract event 0x1151116914515bc0891ff9047a6cb32cf902546f83066499bcf8ba33d2353fa2.
+//
+// Solidity: event ChangedGuard(address guard)
+func (_GnosisSafe *GnosisSafeFilterer) FilterChangedGuard(opts *bind.FilterOpts) (*GnosisSafeChangedGuardIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ChangedGuard")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeChangedGuardIterator{contract: _GnosisSafe.contract, event: "ChangedGuard", logs: logs, sub: sub}, nil
+}
+
+// WatchChangedGuard is a free log subscription operation binding the contract event 0x1151116914515bc0891ff9047a6cb32cf902546f83066499bcf8ba33d2353fa2.
+//
+// Solidity: event ChangedGuard(address guard)
+func (_GnosisSafe *GnosisSafeFilterer) WatchChangedGuard(opts *bind.WatchOpts, sink chan<- *GnosisSafeChangedGuard) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ChangedGuard")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeChangedGuard)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ChangedGuard", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseChangedGuard is a log parse operation binding the contract event 0x1151116914515bc0891ff9047a6cb32cf902546f83066499bcf8ba33d2353fa2.
+//
+// Solidity: event ChangedGuard(address guard)
+func (_GnosisSafe *GnosisSafeFilterer) ParseChangedGuard(log types.Log) (*GnosisSafeChangedGuard, error) {
+	event := new(GnosisSafeChangedGuard)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ChangedGuard", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeChangedThresholdIterator is returned from FilterChangedThreshold and is used to iterate over the raw logs and unpacked data for ChangedThreshold events raised by the GnosisSafe contract.
+type GnosisSafeChangedThresholdIterator struct {
+	Event *GnosisSafeChangedThreshold // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeChangedThresholdIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeChangedThreshold)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeChangedThreshold)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeChangedThresholdIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeChangedThresholdIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeChangedThreshold represents a ChangedThreshold event raised by the GnosisSafe contract.
+type GnosisSafeChangedThreshold struct {
+	Threshold *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterChangedThreshold is a free log retrieval operation binding the contract event 0x610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93.
+//
+// Solidity: event ChangedThreshold(uint256 threshold)
+func (_GnosisSafe *GnosisSafeFilterer) FilterChangedThreshold(opts *bind.FilterOpts) (*GnosisSafeChangedThresholdIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ChangedThreshold")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeChangedThresholdIterator{contract: _GnosisSafe.contract, event: "ChangedThreshold", logs: logs, sub: sub}, nil
+}
+
+// WatchChangedThreshold is a free log subscription operation binding the contract event 0x610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93.
+//
+// Solidity: event ChangedThreshold(uint256 threshold)
+func (_GnosisSafe *GnosisSafeFilterer) WatchChangedThreshold(opts *bind.WatchOpts, sink chan<- *GnosisSafeChangedThreshold) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ChangedThreshold")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeChangedThreshold)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ChangedThreshold", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseChangedThreshold is a log parse operation binding the contract event 0x610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93.
+//
+// Solidity: event ChangedThreshold(uint256 threshold)
+func (_GnosisSafe *GnosisSafeFilterer) ParseChangedThreshold(log types.Log) (*GnosisSafeChangedThreshold, error) {
+	event := new(GnosisSafeChangedThreshold)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ChangedThreshold", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeDisabledModuleIterator is returned from FilterDisabledModule and is used to iterate over the raw logs and unpacked data for DisabledModule events raised by the GnosisSafe contract.
+type GnosisSafeDisabledModuleIterator struct {
+	Event *GnosisSafeDisabledModule // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeDisabledModuleIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeDisabledModule)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeDisabledModule)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeDisabledModuleIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeDisabledModuleIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeDisabledModule represents a DisabledModule event raised by the GnosisSafe contract.
+type GnosisSafeDisabledModule struct {
+	Module common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterDisabledModule is a free log retrieval operation binding the contract event 0xaab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276.
+//
+// Solidity: event DisabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) FilterDisabledModule(opts *bind.FilterOpts) (*GnosisSafeDisabledModuleIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "DisabledModule")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeDisabledModuleIterator{contract: _GnosisSafe.contract, event: "DisabledModule", logs: logs, sub: sub}, nil
+}
+
+// WatchDisabledModule is a free log subscription operation binding the contract event 0xaab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276.
+//
+// Solidity: event DisabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) WatchDisabledModule(opts *bind.WatchOpts, sink chan<- *GnosisSafeDisabledModule) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "DisabledModule")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeDisabledModule)
+				if err := _GnosisSafe.contract.UnpackLog(event, "DisabledModule", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDisabledModule is a log parse operation binding the contract event 0xaab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276.
+//
+// Solidity: event DisabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) ParseDisabledModule(log types.Log) (*GnosisSafeDisabledModule, error) {
+	event := new(GnosisSafeDisabledModule)
+	if err := _GnosisSafe.contract.UnpackLog(event, "DisabledModule", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeEnabledModuleIterator is returned from FilterEnabledModule and is used to iterate over the raw logs and unpacked data for EnabledModule events raised by the GnosisSafe contract.
+type GnosisSafeEnabledModuleIterator struct {
+	Event *GnosisSafeEnabledModule // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeEnabledModuleIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeEnabledModule)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeEnabledModule)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeEnabledModuleIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeEnabledModuleIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeEnabledModule represents a EnabledModule event raised by the GnosisSafe contract.
+type GnosisSafeEnabledModule struct {
+	Module common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterEnabledModule is a free log retrieval operation binding the contract event 0xecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440.
+//
+// Solidity: event EnabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) FilterEnabledModule(opts *bind.FilterOpts) (*GnosisSafeEnabledModuleIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "EnabledModule")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeEnabledModuleIterator{contract: _GnosisSafe.contract, event: "EnabledModule", logs: logs, sub: sub}, nil
+}
+
+// WatchEnabledModule is a free log subscription operation binding the contract event 0xecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440.
+//
+// Solidity: event EnabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) WatchEnabledModule(opts *bind.WatchOpts, sink chan<- *GnosisSafeEnabledModule) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "EnabledModule")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeEnabledModule)
+				if err := _GnosisSafe.contract.UnpackLog(event, "EnabledModule", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEnabledModule is a log parse operation binding the contract event 0xecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440.
+//
+// Solidity: event EnabledModule(address module)
+func (_GnosisSafe *GnosisSafeFilterer) ParseEnabledModule(log types.Log) (*GnosisSafeEnabledModule, error) {
+	event := new(GnosisSafeEnabledModule)
+	if err := _GnosisSafe.contract.UnpackLog(event, "EnabledModule", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeExecutionFailureIterator is returned from FilterExecutionFailure and is used to iterate over the raw logs and unpacked data for ExecutionFailure events raised by the GnosisSafe contract.
+type GnosisSafeExecutionFailureIterator struct {
+	Event *GnosisSafeExecutionFailure // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeExecutionFailureIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeExecutionFailure)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeExecutionFailure)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeExecutionFailureIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeExecutionFailureIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeExecutionFailure represents a ExecutionFailure event raised by the GnosisSafe contract.
+type GnosisSafeExecutionFailure struct {
+	TxHash  [32]byte
+	Payment *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionFailure is a free log retrieval operation binding the contract event 0x23428b18acfb3ea64b08dc0c1d296ea9c09702c09083ca5272e64d115b687d23.
+//
+// Solidity: event ExecutionFailure(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) FilterExecutionFailure(opts *bind.FilterOpts) (*GnosisSafeExecutionFailureIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ExecutionFailure")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeExecutionFailureIterator{contract: _GnosisSafe.contract, event: "ExecutionFailure", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionFailure is a free log subscription operation binding the contract event 0x23428b18acfb3ea64b08dc0c1d296ea9c09702c09083ca5272e64d115b687d23.
+//
+// Solidity: event ExecutionFailure(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) WatchExecutionFailure(opts *bind.WatchOpts, sink chan<- *GnosisSafeExecutionFailure) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ExecutionFailure")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeExecutionFailure)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFailure", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionFailure is a log parse operation binding the contract event 0x23428b18acfb3ea64b08dc0c1d296ea9c09702c09083ca5272e64d115b687d23.
+//
+// Solidity: event ExecutionFailure(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) ParseExecutionFailure(log types.Log) (*GnosisSafeExecutionFailure, error) {
+	event := new(GnosisSafeExecutionFailure)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFailure", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeExecutionFromModuleFailureIterator is returned from FilterExecutionFromModuleFailure and is used to iterate over the raw logs and unpacked data for ExecutionFromModuleFailure events raised by the GnosisSafe contract.
+type GnosisSafeExecutionFromModuleFailureIterator struct {
+	Event *GnosisSafeExecutionFromModuleFailure // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeExecutionFromModuleFailureIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeExecutionFromModuleFailure)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeExecutionFromModuleFailure)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeExecutionFromModuleFailureIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeExecutionFromModuleFailureIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeExecutionFromModuleFailure represents a ExecutionFromModuleFailure event raised by the GnosisSafe contract.
+type GnosisSafeExecutionFromModuleFailure struct {
+	Module common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionFromModuleFailure is a free log retrieval operation binding the contract event 0xacd2c8702804128fdb0db2bb49f6d127dd0181c13fd45dbfe16de0930e2bd375.
+//
+// Solidity: event ExecutionFromModuleFailure(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) FilterExecutionFromModuleFailure(opts *bind.FilterOpts, module []common.Address) (*GnosisSafeExecutionFromModuleFailureIterator, error) {
+
+	var moduleRule []interface{}
+	for _, moduleItem := range module {
+		moduleRule = append(moduleRule, moduleItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ExecutionFromModuleFailure", moduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeExecutionFromModuleFailureIterator{contract: _GnosisSafe.contract, event: "ExecutionFromModuleFailure", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionFromModuleFailure is a free log subscription operation binding the contract event 0xacd2c8702804128fdb0db2bb49f6d127dd0181c13fd45dbfe16de0930e2bd375.
+//
+// Solidity: event ExecutionFromModuleFailure(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) WatchExecutionFromModuleFailure(opts *bind.WatchOpts, sink chan<- *GnosisSafeExecutionFromModuleFailure, module []common.Address) (event.Subscription, error) {
+
+	var moduleRule []interface{}
+	for _, moduleItem := range module {
+		moduleRule = append(moduleRule, moduleItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ExecutionFromModuleFailure", moduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeExecutionFromModuleFailure)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFromModuleFailure", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionFromModuleFailure is a log parse operation binding the contract event 0xacd2c8702804128fdb0db2bb49f6d127dd0181c13fd45dbfe16de0930e2bd375.
+//
+// Solidity: event ExecutionFromModuleFailure(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) ParseExecutionFromModuleFailure(log types.Log) (*GnosisSafeExecutionFromModuleFailure, error) {
+	event := new(GnosisSafeExecutionFromModuleFailure)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFromModuleFailure", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeExecutionFromModuleSuccessIterator is returned from FilterExecutionFromModuleSuccess and is used to iterate over the raw logs and unpacked data for ExecutionFromModuleSuccess events raised by the GnosisSafe contract.
+type GnosisSafeExecutionFromModuleSuccessIterator struct {
+	Event *GnosisSafeExecutionFromModuleSuccess // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeExecutionFromModuleSuccessIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeExecutionFromModuleSuccess)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeExecutionFromModuleSuccess)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeExecutionFromModuleSuccessIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeExecutionFromModuleSuccessIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeExecutionFromModuleSuccess represents a ExecutionFromModuleSuccess event raised by the GnosisSafe contract.
+type GnosisSafeExecutionFromModuleSuccess struct {
+	Module common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionFromModuleSuccess is a free log retrieval operation binding the contract event 0x6895c13664aa4f67288b25d7a21d7aaa34916e355fb9b6fae0a139a9085becb8.
+//
+// Solidity: event ExecutionFromModuleSuccess(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) FilterExecutionFromModuleSuccess(opts *bind.FilterOpts, module []common.Address) (*GnosisSafeExecutionFromModuleSuccessIterator, error) {
+
+	var moduleRule []interface{}
+	for _, moduleItem := range module {
+		moduleRule = append(moduleRule, moduleItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ExecutionFromModuleSuccess", moduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeExecutionFromModuleSuccessIterator{contract: _GnosisSafe.contract, event: "ExecutionFromModuleSuccess", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionFromModuleSuccess is a free log subscription operation binding the contract event 0x6895c13664aa4f67288b25d7a21d7aaa34916e355fb9b6fae0a139a9085becb8.
+//
+// Solidity: event ExecutionFromModuleSuccess(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) WatchExecutionFromModuleSuccess(opts *bind.WatchOpts, sink chan<- *GnosisSafeExecutionFromModuleSuccess, module []common.Address) (event.Subscription, error) {
+
+	var moduleRule []interface{}
+	for _, moduleItem := range module {
+		moduleRule = append(moduleRule, moduleItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ExecutionFromModuleSuccess", moduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeExecutionFromModuleSuccess)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFromModuleSuccess", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionFromModuleSuccess is a log parse operation binding the contract event 0x6895c13664aa4f67288b25d7a21d7aaa34916e355fb9b6fae0a139a9085becb8.
+//
+// Solidity: event ExecutionFromModuleSuccess(address indexed module)
+func (_GnosisSafe *GnosisSafeFilterer) ParseExecutionFromModuleSuccess(log types.Log) (*GnosisSafeExecutionFromModuleSuccess, error) {
+	event := new(GnosisSafeExecutionFromModuleSuccess)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionFromModuleSuccess", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeExecutionSuccessIterator is returned from FilterExecutionSuccess and is used to iterate over the raw logs and unpacked data for ExecutionSuccess events raised by the GnosisSafe contract.
+type GnosisSafeExecutionSuccessIterator struct {
+	Event *GnosisSafeExecutionSuccess // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeExecutionSuccessIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeExecutionSuccess)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeExecutionSuccess)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeExecutionSuccessIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeExecutionSuccessIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeExecutionSuccess represents a ExecutionSuccess event raised by the GnosisSafe contract.
+type GnosisSafeExecutionSuccess struct {
+	TxHash  [32]byte
+	Payment *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionSuccess is a free log retrieval operation binding the contract event 0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e.
+//
+// Solidity: event ExecutionSuccess(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) FilterExecutionSuccess(opts *bind.FilterOpts) (*GnosisSafeExecutionSuccessIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "ExecutionSuccess")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeExecutionSuccessIterator{contract: _GnosisSafe.contract, event: "ExecutionSuccess", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionSuccess is a free log subscription operation binding the contract event 0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e.
+//
+// Solidity: event ExecutionSuccess(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) WatchExecutionSuccess(opts *bind.WatchOpts, sink chan<- *GnosisSafeExecutionSuccess) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "ExecutionSuccess")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeExecutionSuccess)
+				if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionSuccess", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionSuccess is a log parse operation binding the contract event 0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e.
+//
+// Solidity: event ExecutionSuccess(bytes32 txHash, uint256 payment)
+func (_GnosisSafe *GnosisSafeFilterer) ParseExecutionSuccess(log types.Log) (*GnosisSafeExecutionSuccess, error) {
+	event := new(GnosisSafeExecutionSuccess)
+	if err := _GnosisSafe.contract.UnpackLog(event, "ExecutionSuccess", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeRemovedOwnerIterator is returned from FilterRemovedOwner and is used to iterate over the raw logs and unpacked data for RemovedOwner events raised by the GnosisSafe contract.
+type GnosisSafeRemovedOwnerIterator struct {
+	Event *GnosisSafeRemovedOwner // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeRemovedOwnerIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeRemovedOwner)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeRemovedOwner)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeRemovedOwnerIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeRemovedOwnerIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeRemovedOwner represents a RemovedOwner event raised by the GnosisSafe contract.
+type GnosisSafeRemovedOwner struct {
+	Owner common.Address
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterRemovedOwner is a free log retrieval operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) FilterRemovedOwner(opts *bind.FilterOpts) (*GnosisSafeRemovedOwnerIterator, error) {
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "RemovedOwner")
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeRemovedOwnerIterator{contract: _GnosisSafe.contract, event: "RemovedOwner", logs: logs, sub: sub}, nil
+}
+
+// WatchRemovedOwner is a free log subscription operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) WatchRemovedOwner(opts *bind.WatchOpts, sink chan<- *GnosisSafeRemovedOwner) (event.Subscription, error) {
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "RemovedOwner")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeRemovedOwner)
+				if err := _GnosisSafe.contract.UnpackLog(event, "RemovedOwner", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRemovedOwner is a log parse operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address owner)
+func (_GnosisSafe *GnosisSafeFilterer) ParseRemovedOwner(log types.Log) (*GnosisSafeRemovedOwner, error) {
+	event := new(GnosisSafeRemovedOwner)
+	if err := _GnosisSafe.contract.UnpackLog(event, "RemovedOwner", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeSafeReceivedIterator is returned from FilterSafeReceived and is used to iterate over the raw logs and unpacked data for SafeReceived events raised by the GnosisSafe contract.
+type GnosisSafeSafeReceivedIterator struct {
+	Event *GnosisSafeSafeReceived // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeSafeReceivedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeSafeReceived)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeSafeReceived)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeSafeReceivedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeSafeReceivedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeSafeReceived represents a SafeReceived event raised by the GnosisSafe contract.
+type GnosisSafeSafeReceived struct {
+	Sender common.Address
+	Value  *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterSafeReceived is a free log retrieval operation binding the contract event 0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d.
+//
+// Solidity: event SafeReceived(address indexed sender, uint256 value)
+func (_GnosisSafe *GnosisSafeFilterer) FilterSafeReceived(opts *bind.FilterOpts, sender []common.Address) (*GnosisSafeSafeReceivedIterator, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "SafeReceived", senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeSafeReceivedIterator{contract: _GnosisSafe.contract, event: "SafeReceived", logs: logs, sub: sub}, nil
+}
+
+// WatchSafeReceived is a free log subscription operation binding the contract event 0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d.
+//
+// Solidity: event SafeReceived(address indexed sender, uint256 value)
+func (_GnosisSafe *GnosisSafeFilterer) WatchSafeReceived(opts *bind.WatchOpts, sink chan<- *GnosisSafeSafeReceived, sender []common.Address) (event.Subscription, error) {
+
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "SafeReceived", senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeSafeReceived)
+				if err := _GnosisSafe.contract.UnpackLog(event, "SafeReceived", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSafeReceived is a log parse operation binding the contract event 0x3d0ce9bfc3ed7d6862dbb28b2dea94561fe714a1b4d019aa8af39730d1ad7c3d.
+//
+// Solidity: event SafeReceived(address indexed sender, uint256 value)
+func (_GnosisSafe *GnosisSafeFilterer) ParseSafeReceived(log types.Log) (*GnosisSafeSafeReceived, error) {
+	event := new(GnosisSafeSafeReceived)
+	if err := _GnosisSafe.contract.UnpackLog(event, "SafeReceived", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeSafeSetupIterator is returned from FilterSafeSetup and is used to iterate over the raw logs and unpacked data for SafeSetup events raised by the GnosisSafe contract.
+type GnosisSafeSafeSetupIterator struct {
+	Event *GnosisSafeSafeSetup // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeSafeSetupIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeSafeSetup)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeSafeSetup)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeSafeSetupIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeSafeSetupIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeSafeSetup represents a SafeSetup event raised by the GnosisSafe contract.
+type GnosisSafeSafeSetup struct {
+	Initiator       common.Address
+	Owners          []common.Address
+	Threshold       *big.Int
+	Initializer     common.Address
+	FallbackHandler common.Address
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterSafeSetup is a free log retrieval operation binding the contract event 0x141df868a6331af528e38c83b7aa03edc19be66e37ae67f9285bf4f8e3c6a1a8.
+//
+// Solidity: event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)
+func (_GnosisSafe *GnosisSafeFilterer) FilterSafeSetup(opts *bind.FilterOpts, initiator []common.Address) (*GnosisSafeSafeSetupIterator, error) {
+
+	var initiatorRule []interface{}
+	for _, initiatorItem := range initiator {
+		initiatorRule = append(initiatorRule, initiatorItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "SafeSetup", initiatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeSafeSetupIterator{contract: _GnosisSafe.contract, event: "SafeSetup", logs: logs, sub: sub}, nil
+}
+
+// WatchSafeSetup is a free log subscription operation binding the contract event 0x141df868a6331af528e38c83b7aa03edc19be66e37ae67f9285bf4f8e3c6a1a8.
+//
+// Solidity: event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)
+func (_GnosisSafe *GnosisSafeFilterer) WatchSafeSetup(opts *bind.WatchOpts, sink chan<- *GnosisSafeSafeSetup, initiator []common.Address) (event.Subscription, error) {
+
+	var initiatorRule []interface{}
+	for _, initiatorItem := range initiator {
+		initiatorRule = append(initiatorRule, initiatorItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "SafeSetup", initiatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeSafeSetup)
+				if err := _GnosisSafe.contract.UnpackLog(event, "SafeSetup", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSafeSetup is a log parse operation binding the contract event 0x141df868a6331af528e38c83b7aa03edc19be66e37ae67f9285bf4f8e3c6a1a8.
+//
+// Solidity: event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)
+func (_GnosisSafe *GnosisSafeFilterer) ParseSafeSetup(log types.Log) (*GnosisSafeSafeSetup, error) {
+	event := new(GnosisSafeSafeSetup)
+	if err := _GnosisSafe.contract.UnpackLog(event, "SafeSetup", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GnosisSafeSignMsgIterator is returned from FilterSignMsg and is used to iterate over the raw logs and unpacked data for SignMsg events raised by the GnosisSafe contract.
+type GnosisSafeSignMsgIterator struct {
+	Event *GnosisSafeSignMsg // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GnosisSafeSignMsgIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GnosisSafeSignMsg)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GnosisSafeSignMsg)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GnosisSafeSignMsgIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GnosisSafeSignMsgIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GnosisSafeSignMsg represents a SignMsg event raised by the GnosisSafe contract.
+type GnosisSafeSignMsg struct {
+	MsgHash [32]byte
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterSignMsg is a free log retrieval operation binding the contract event 0xe7f4675038f4f6034dfcbbb24c4dc08e4ebf10eb9d257d3d02c0f38d122ac6e4.
+//
+// Solidity: event SignMsg(bytes32 indexed msgHash)
+func (_GnosisSafe *GnosisSafeFilterer) FilterSignMsg(opts *bind.FilterOpts, msgHash [][32]byte) (*GnosisSafeSignMsgIterator, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.FilterLogs(opts, "SignMsg", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GnosisSafeSignMsgIterator{contract: _GnosisSafe.contract, event: "SignMsg", logs: logs, sub: sub}, nil
+}
+
+// WatchSignMsg is a free log subscription operation binding the contract event 0xe7f4675038f4f6034dfcbbb24c4dc08e4ebf10eb9d257d3d02c0f38d122ac6e4.
+//
+// Solidity: event SignMsg(bytes32 indexed msgHash)
+func (_GnosisSafe *GnosisSafeFilterer) WatchSignMsg(opts *bind.WatchOpts, sink chan<- *GnosisSafeSignMsg, msgHash [][32]byte) (event.Subscription, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _GnosisSafe.contract.WatchLogs(opts, "SignMsg", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GnosisSafeSignMsg)
+				if err := _GnosisSafe.contract.UnpackLog(event, "SignMsg", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSignMsg is a log parse operation binding the contract event 0xe7f4675038f4f6034dfcbbb24c4dc08e4ebf10eb9d257d3d02c0f38d122ac6e4.
+//
+// Solidity: event SignMsg(bytes32 indexed msgHash)
+func (_GnosisSafe *GnosisSafeFilterer) ParseSignMsg(log types.Log) (*GnosisSafeSignMsg, error) {
+	event := new(GnosisSafeSignMsg)
+	if err := _GnosisSafe.contract.UnpackLog(event, "SignMsg", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/op-monitorism/liveness_expiration/bindings/LivenessGuard.go
+++ b/op-monitorism/liveness_expiration/bindings/LivenessGuard.go
@@ -1,0 +1,471 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// LivenessGuardMetaData contains all meta data concerning the LivenessGuard contract.
+var LivenessGuardMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_safe\",\"type\":\"address\",\"internalType\":\"contractGnosisSafe\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"checkAfterExecution\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"checkTransaction\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"operation\",\"type\":\"uint8\",\"internalType\":\"enumEnum.Operation\"},{\"name\":\"safeTxGas\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"baseGas\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gasPrice\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gasToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"refundReceiver\",\"type\":\"address\",\"internalType\":\"addresspayable\"},{\"name\":\"signatures\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"msgSender\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"lastLive\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"safe\",\"inputs\":[],\"outputs\":[{\"name\":\"safe_\",\"type\":\"address\",\"internalType\":\"contractGnosisSafe\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"showLiveness\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"OwnerRecorded\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false}]",
+}
+
+// LivenessGuardABI is the input ABI used to generate the binding from.
+// Deprecated: Use LivenessGuardMetaData.ABI instead.
+var LivenessGuardABI = LivenessGuardMetaData.ABI
+
+// LivenessGuard is an auto generated Go binding around an Ethereum contract.
+type LivenessGuard struct {
+	LivenessGuardCaller     // Read-only binding to the contract
+	LivenessGuardTransactor // Write-only binding to the contract
+	LivenessGuardFilterer   // Log filterer for contract events
+}
+
+// LivenessGuardCaller is an auto generated read-only Go binding around an Ethereum contract.
+type LivenessGuardCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessGuardTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type LivenessGuardTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessGuardFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type LivenessGuardFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessGuardSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type LivenessGuardSession struct {
+	Contract     *LivenessGuard    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// LivenessGuardCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type LivenessGuardCallerSession struct {
+	Contract *LivenessGuardCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// LivenessGuardTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type LivenessGuardTransactorSession struct {
+	Contract     *LivenessGuardTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// LivenessGuardRaw is an auto generated low-level Go binding around an Ethereum contract.
+type LivenessGuardRaw struct {
+	Contract *LivenessGuard // Generic contract binding to access the raw methods on
+}
+
+// LivenessGuardCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type LivenessGuardCallerRaw struct {
+	Contract *LivenessGuardCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// LivenessGuardTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type LivenessGuardTransactorRaw struct {
+	Contract *LivenessGuardTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewLivenessGuard creates a new instance of LivenessGuard, bound to a specific deployed contract.
+func NewLivenessGuard(address common.Address, backend bind.ContractBackend) (*LivenessGuard, error) {
+	contract, err := bindLivenessGuard(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessGuard{LivenessGuardCaller: LivenessGuardCaller{contract: contract}, LivenessGuardTransactor: LivenessGuardTransactor{contract: contract}, LivenessGuardFilterer: LivenessGuardFilterer{contract: contract}}, nil
+}
+
+// NewLivenessGuardCaller creates a new read-only instance of LivenessGuard, bound to a specific deployed contract.
+func NewLivenessGuardCaller(address common.Address, caller bind.ContractCaller) (*LivenessGuardCaller, error) {
+	contract, err := bindLivenessGuard(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessGuardCaller{contract: contract}, nil
+}
+
+// NewLivenessGuardTransactor creates a new write-only instance of LivenessGuard, bound to a specific deployed contract.
+func NewLivenessGuardTransactor(address common.Address, transactor bind.ContractTransactor) (*LivenessGuardTransactor, error) {
+	contract, err := bindLivenessGuard(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessGuardTransactor{contract: contract}, nil
+}
+
+// NewLivenessGuardFilterer creates a new log filterer instance of LivenessGuard, bound to a specific deployed contract.
+func NewLivenessGuardFilterer(address common.Address, filterer bind.ContractFilterer) (*LivenessGuardFilterer, error) {
+	contract, err := bindLivenessGuard(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessGuardFilterer{contract: contract}, nil
+}
+
+// bindLivenessGuard binds a generic wrapper to an already deployed contract.
+func bindLivenessGuard(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := LivenessGuardMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_LivenessGuard *LivenessGuardRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _LivenessGuard.Contract.LivenessGuardCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_LivenessGuard *LivenessGuardRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.LivenessGuardTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_LivenessGuard *LivenessGuardRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.LivenessGuardTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_LivenessGuard *LivenessGuardCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _LivenessGuard.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_LivenessGuard *LivenessGuardTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_LivenessGuard *LivenessGuardTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.contract.Transact(opts, method, params...)
+}
+
+// LastLive is a free data retrieval call binding the contract method 0xe458779b.
+//
+// Solidity: function lastLive(address ) view returns(uint256)
+func (_LivenessGuard *LivenessGuardCaller) LastLive(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _LivenessGuard.contract.Call(opts, &out, "lastLive", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LastLive is a free data retrieval call binding the contract method 0xe458779b.
+//
+// Solidity: function lastLive(address ) view returns(uint256)
+func (_LivenessGuard *LivenessGuardSession) LastLive(arg0 common.Address) (*big.Int, error) {
+	return _LivenessGuard.Contract.LastLive(&_LivenessGuard.CallOpts, arg0)
+}
+
+// LastLive is a free data retrieval call binding the contract method 0xe458779b.
+//
+// Solidity: function lastLive(address ) view returns(uint256)
+func (_LivenessGuard *LivenessGuardCallerSession) LastLive(arg0 common.Address) (*big.Int, error) {
+	return _LivenessGuard.Contract.LastLive(&_LivenessGuard.CallOpts, arg0)
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessGuard *LivenessGuardCaller) Safe(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _LivenessGuard.contract.Call(opts, &out, "safe")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessGuard *LivenessGuardSession) Safe() (common.Address, error) {
+	return _LivenessGuard.Contract.Safe(&_LivenessGuard.CallOpts)
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessGuard *LivenessGuardCallerSession) Safe() (common.Address, error) {
+	return _LivenessGuard.Contract.Safe(&_LivenessGuard.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessGuard *LivenessGuardCaller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _LivenessGuard.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessGuard *LivenessGuardSession) Version() (string, error) {
+	return _LivenessGuard.Contract.Version(&_LivenessGuard.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessGuard *LivenessGuardCallerSession) Version() (string, error) {
+	return _LivenessGuard.Contract.Version(&_LivenessGuard.CallOpts)
+}
+
+// CheckAfterExecution is a paid mutator transaction binding the contract method 0x93271368.
+//
+// Solidity: function checkAfterExecution(bytes32 , bool ) returns()
+func (_LivenessGuard *LivenessGuardTransactor) CheckAfterExecution(opts *bind.TransactOpts, arg0 [32]byte, arg1 bool) (*types.Transaction, error) {
+	return _LivenessGuard.contract.Transact(opts, "checkAfterExecution", arg0, arg1)
+}
+
+// CheckAfterExecution is a paid mutator transaction binding the contract method 0x93271368.
+//
+// Solidity: function checkAfterExecution(bytes32 , bool ) returns()
+func (_LivenessGuard *LivenessGuardSession) CheckAfterExecution(arg0 [32]byte, arg1 bool) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.CheckAfterExecution(&_LivenessGuard.TransactOpts, arg0, arg1)
+}
+
+// CheckAfterExecution is a paid mutator transaction binding the contract method 0x93271368.
+//
+// Solidity: function checkAfterExecution(bytes32 , bool ) returns()
+func (_LivenessGuard *LivenessGuardTransactorSession) CheckAfterExecution(arg0 [32]byte, arg1 bool) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.CheckAfterExecution(&_LivenessGuard.TransactOpts, arg0, arg1)
+}
+
+// CheckTransaction is a paid mutator transaction binding the contract method 0x75f0bb52.
+//
+// Solidity: function checkTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures, address msgSender) returns()
+func (_LivenessGuard *LivenessGuardTransactor) CheckTransaction(opts *bind.TransactOpts, to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte, msgSender common.Address) (*types.Transaction, error) {
+	return _LivenessGuard.contract.Transact(opts, "checkTransaction", to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, msgSender)
+}
+
+// CheckTransaction is a paid mutator transaction binding the contract method 0x75f0bb52.
+//
+// Solidity: function checkTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures, address msgSender) returns()
+func (_LivenessGuard *LivenessGuardSession) CheckTransaction(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte, msgSender common.Address) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.CheckTransaction(&_LivenessGuard.TransactOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, msgSender)
+}
+
+// CheckTransaction is a paid mutator transaction binding the contract method 0x75f0bb52.
+//
+// Solidity: function checkTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures, address msgSender) returns()
+func (_LivenessGuard *LivenessGuardTransactorSession) CheckTransaction(to common.Address, value *big.Int, data []byte, operation uint8, safeTxGas *big.Int, baseGas *big.Int, gasPrice *big.Int, gasToken common.Address, refundReceiver common.Address, signatures []byte, msgSender common.Address) (*types.Transaction, error) {
+	return _LivenessGuard.Contract.CheckTransaction(&_LivenessGuard.TransactOpts, to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, msgSender)
+}
+
+// ShowLiveness is a paid mutator transaction binding the contract method 0x4c205d0d.
+//
+// Solidity: function showLiveness() returns()
+func (_LivenessGuard *LivenessGuardTransactor) ShowLiveness(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _LivenessGuard.contract.Transact(opts, "showLiveness")
+}
+
+// ShowLiveness is a paid mutator transaction binding the contract method 0x4c205d0d.
+//
+// Solidity: function showLiveness() returns()
+func (_LivenessGuard *LivenessGuardSession) ShowLiveness() (*types.Transaction, error) {
+	return _LivenessGuard.Contract.ShowLiveness(&_LivenessGuard.TransactOpts)
+}
+
+// ShowLiveness is a paid mutator transaction binding the contract method 0x4c205d0d.
+//
+// Solidity: function showLiveness() returns()
+func (_LivenessGuard *LivenessGuardTransactorSession) ShowLiveness() (*types.Transaction, error) {
+	return _LivenessGuard.Contract.ShowLiveness(&_LivenessGuard.TransactOpts)
+}
+
+// LivenessGuardOwnerRecordedIterator is returned from FilterOwnerRecorded and is used to iterate over the raw logs and unpacked data for OwnerRecorded events raised by the LivenessGuard contract.
+type LivenessGuardOwnerRecordedIterator struct {
+	Event *LivenessGuardOwnerRecorded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *LivenessGuardOwnerRecordedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(LivenessGuardOwnerRecorded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(LivenessGuardOwnerRecorded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *LivenessGuardOwnerRecordedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *LivenessGuardOwnerRecordedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// LivenessGuardOwnerRecorded represents a OwnerRecorded event raised by the LivenessGuard contract.
+type LivenessGuardOwnerRecorded struct {
+	Owner common.Address
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnerRecorded is a free log retrieval operation binding the contract event 0x833bc129023866d52116d61e94b791eb8be46f05709362e0bcf1fe7c1a8c225c.
+//
+// Solidity: event OwnerRecorded(address owner)
+func (_LivenessGuard *LivenessGuardFilterer) FilterOwnerRecorded(opts *bind.FilterOpts) (*LivenessGuardOwnerRecordedIterator, error) {
+
+	logs, sub, err := _LivenessGuard.contract.FilterLogs(opts, "OwnerRecorded")
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessGuardOwnerRecordedIterator{contract: _LivenessGuard.contract, event: "OwnerRecorded", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnerRecorded is a free log subscription operation binding the contract event 0x833bc129023866d52116d61e94b791eb8be46f05709362e0bcf1fe7c1a8c225c.
+//
+// Solidity: event OwnerRecorded(address owner)
+func (_LivenessGuard *LivenessGuardFilterer) WatchOwnerRecorded(opts *bind.WatchOpts, sink chan<- *LivenessGuardOwnerRecorded) (event.Subscription, error) {
+
+	logs, sub, err := _LivenessGuard.contract.WatchLogs(opts, "OwnerRecorded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(LivenessGuardOwnerRecorded)
+				if err := _LivenessGuard.contract.UnpackLog(event, "OwnerRecorded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnerRecorded is a log parse operation binding the contract event 0x833bc129023866d52116d61e94b791eb8be46f05709362e0bcf1fe7c1a8c225c.
+//
+// Solidity: event OwnerRecorded(address owner)
+func (_LivenessGuard *LivenessGuardFilterer) ParseOwnerRecorded(log types.Log) (*LivenessGuardOwnerRecorded, error) {
+	event := new(LivenessGuardOwnerRecorded)
+	if err := _LivenessGuard.contract.UnpackLog(event, "OwnerRecorded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/op-monitorism/liveness_expiration/bindings/LivenessModul.go
+++ b/op-monitorism/liveness_expiration/bindings/LivenessModul.go
@@ -1,0 +1,789 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// LivenessModuleMetaData contains all meta data concerning the LivenessModule contract.
+var LivenessModuleMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_safe\",\"type\":\"address\",\"internalType\":\"contractGnosisSafe\"},{\"name\":\"_livenessGuard\",\"type\":\"address\",\"internalType\":\"contractLivenessGuard\"},{\"name\":\"_livenessInterval\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_minOwners\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_thresholdPercentage\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_fallbackOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"canRemove\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"canRemove_\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"fallbackOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"fallbackOwner_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRequiredThreshold\",\"inputs\":[{\"name\":\"_numOwners\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"threshold_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"livenessGuard\",\"inputs\":[],\"outputs\":[{\"name\":\"livenessGuard_\",\"type\":\"address\",\"internalType\":\"contractLivenessGuard\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"livenessInterval\",\"inputs\":[],\"outputs\":[{\"name\":\"livenessInterval_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minOwners\",\"inputs\":[],\"outputs\":[{\"name\":\"minOwners_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ownershipTransferredToFallback\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"removeOwners\",\"inputs\":[{\"name\":\"_previousOwners\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"_ownersToRemove\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"safe\",\"inputs\":[],\"outputs\":[{\"name\":\"safe_\",\"type\":\"address\",\"internalType\":\"contractGnosisSafe\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"thresholdPercentage\",\"inputs\":[],\"outputs\":[{\"name\":\"thresholdPercentage_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"OwnershipTransferredToFallback\",\"inputs\":[],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RemovedOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"OwnerRemovalFailed\",\"inputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}]}]",
+}
+
+// LivenessModuleABI is the input ABI used to generate the binding from.
+// Deprecated: Use LivenessModuleMetaData.ABI instead.
+var LivenessModuleABI = LivenessModuleMetaData.ABI
+
+// LivenessModule is an auto generated Go binding around an Ethereum contract.
+type LivenessModule struct {
+	LivenessModuleCaller     // Read-only binding to the contract
+	LivenessModuleTransactor // Write-only binding to the contract
+	LivenessModuleFilterer   // Log filterer for contract events
+}
+
+// LivenessModuleCaller is an auto generated read-only Go binding around an Ethereum contract.
+type LivenessModuleCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessModuleTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type LivenessModuleTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessModuleFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type LivenessModuleFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LivenessModuleSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type LivenessModuleSession struct {
+	Contract     *LivenessModule   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// LivenessModuleCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type LivenessModuleCallerSession struct {
+	Contract *LivenessModuleCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// LivenessModuleTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type LivenessModuleTransactorSession struct {
+	Contract     *LivenessModuleTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// LivenessModuleRaw is an auto generated low-level Go binding around an Ethereum contract.
+type LivenessModuleRaw struct {
+	Contract *LivenessModule // Generic contract binding to access the raw methods on
+}
+
+// LivenessModuleCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type LivenessModuleCallerRaw struct {
+	Contract *LivenessModuleCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// LivenessModuleTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type LivenessModuleTransactorRaw struct {
+	Contract *LivenessModuleTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewLivenessModule creates a new instance of LivenessModule, bound to a specific deployed contract.
+func NewLivenessModule(address common.Address, backend bind.ContractBackend) (*LivenessModule, error) {
+	contract, err := bindLivenessModule(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModule{LivenessModuleCaller: LivenessModuleCaller{contract: contract}, LivenessModuleTransactor: LivenessModuleTransactor{contract: contract}, LivenessModuleFilterer: LivenessModuleFilterer{contract: contract}}, nil
+}
+
+// NewLivenessModuleCaller creates a new read-only instance of LivenessModule, bound to a specific deployed contract.
+func NewLivenessModuleCaller(address common.Address, caller bind.ContractCaller) (*LivenessModuleCaller, error) {
+	contract, err := bindLivenessModule(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModuleCaller{contract: contract}, nil
+}
+
+// NewLivenessModuleTransactor creates a new write-only instance of LivenessModule, bound to a specific deployed contract.
+func NewLivenessModuleTransactor(address common.Address, transactor bind.ContractTransactor) (*LivenessModuleTransactor, error) {
+	contract, err := bindLivenessModule(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModuleTransactor{contract: contract}, nil
+}
+
+// NewLivenessModuleFilterer creates a new log filterer instance of LivenessModule, bound to a specific deployed contract.
+func NewLivenessModuleFilterer(address common.Address, filterer bind.ContractFilterer) (*LivenessModuleFilterer, error) {
+	contract, err := bindLivenessModule(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModuleFilterer{contract: contract}, nil
+}
+
+// bindLivenessModule binds a generic wrapper to an already deployed contract.
+func bindLivenessModule(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := LivenessModuleMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_LivenessModule *LivenessModuleRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _LivenessModule.Contract.LivenessModuleCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_LivenessModule *LivenessModuleRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _LivenessModule.Contract.LivenessModuleTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_LivenessModule *LivenessModuleRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _LivenessModule.Contract.LivenessModuleTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_LivenessModule *LivenessModuleCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _LivenessModule.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_LivenessModule *LivenessModuleTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _LivenessModule.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_LivenessModule *LivenessModuleTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _LivenessModule.Contract.contract.Transact(opts, method, params...)
+}
+
+// CanRemove is a free data retrieval call binding the contract method 0xd45996f1.
+//
+// Solidity: function canRemove(address _owner) view returns(bool canRemove_)
+func (_LivenessModule *LivenessModuleCaller) CanRemove(opts *bind.CallOpts, _owner common.Address) (bool, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "canRemove", _owner)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// CanRemove is a free data retrieval call binding the contract method 0xd45996f1.
+//
+// Solidity: function canRemove(address _owner) view returns(bool canRemove_)
+func (_LivenessModule *LivenessModuleSession) CanRemove(_owner common.Address) (bool, error) {
+	return _LivenessModule.Contract.CanRemove(&_LivenessModule.CallOpts, _owner)
+}
+
+// CanRemove is a free data retrieval call binding the contract method 0xd45996f1.
+//
+// Solidity: function canRemove(address _owner) view returns(bool canRemove_)
+func (_LivenessModule *LivenessModuleCallerSession) CanRemove(_owner common.Address) (bool, error) {
+	return _LivenessModule.Contract.CanRemove(&_LivenessModule.CallOpts, _owner)
+}
+
+// FallbackOwner is a free data retrieval call binding the contract method 0x602b263b.
+//
+// Solidity: function fallbackOwner() view returns(address fallbackOwner_)
+func (_LivenessModule *LivenessModuleCaller) FallbackOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "fallbackOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// FallbackOwner is a free data retrieval call binding the contract method 0x602b263b.
+//
+// Solidity: function fallbackOwner() view returns(address fallbackOwner_)
+func (_LivenessModule *LivenessModuleSession) FallbackOwner() (common.Address, error) {
+	return _LivenessModule.Contract.FallbackOwner(&_LivenessModule.CallOpts)
+}
+
+// FallbackOwner is a free data retrieval call binding the contract method 0x602b263b.
+//
+// Solidity: function fallbackOwner() view returns(address fallbackOwner_)
+func (_LivenessModule *LivenessModuleCallerSession) FallbackOwner() (common.Address, error) {
+	return _LivenessModule.Contract.FallbackOwner(&_LivenessModule.CallOpts)
+}
+
+// GetRequiredThreshold is a free data retrieval call binding the contract method 0x86644d1e.
+//
+// Solidity: function getRequiredThreshold(uint256 _numOwners) view returns(uint256 threshold_)
+func (_LivenessModule *LivenessModuleCaller) GetRequiredThreshold(opts *bind.CallOpts, _numOwners *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "getRequiredThreshold", _numOwners)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRequiredThreshold is a free data retrieval call binding the contract method 0x86644d1e.
+//
+// Solidity: function getRequiredThreshold(uint256 _numOwners) view returns(uint256 threshold_)
+func (_LivenessModule *LivenessModuleSession) GetRequiredThreshold(_numOwners *big.Int) (*big.Int, error) {
+	return _LivenessModule.Contract.GetRequiredThreshold(&_LivenessModule.CallOpts, _numOwners)
+}
+
+// GetRequiredThreshold is a free data retrieval call binding the contract method 0x86644d1e.
+//
+// Solidity: function getRequiredThreshold(uint256 _numOwners) view returns(uint256 threshold_)
+func (_LivenessModule *LivenessModuleCallerSession) GetRequiredThreshold(_numOwners *big.Int) (*big.Int, error) {
+	return _LivenessModule.Contract.GetRequiredThreshold(&_LivenessModule.CallOpts, _numOwners)
+}
+
+// LivenessGuard is a free data retrieval call binding the contract method 0xbe81c694.
+//
+// Solidity: function livenessGuard() view returns(address livenessGuard_)
+func (_LivenessModule *LivenessModuleCaller) LivenessGuard(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "livenessGuard")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LivenessGuard is a free data retrieval call binding the contract method 0xbe81c694.
+//
+// Solidity: function livenessGuard() view returns(address livenessGuard_)
+func (_LivenessModule *LivenessModuleSession) LivenessGuard() (common.Address, error) {
+	return _LivenessModule.Contract.LivenessGuard(&_LivenessModule.CallOpts)
+}
+
+// LivenessGuard is a free data retrieval call binding the contract method 0xbe81c694.
+//
+// Solidity: function livenessGuard() view returns(address livenessGuard_)
+func (_LivenessModule *LivenessModuleCallerSession) LivenessGuard() (common.Address, error) {
+	return _LivenessModule.Contract.LivenessGuard(&_LivenessModule.CallOpts)
+}
+
+// LivenessInterval is a free data retrieval call binding the contract method 0x38af7c5c.
+//
+// Solidity: function livenessInterval() view returns(uint256 livenessInterval_)
+func (_LivenessModule *LivenessModuleCaller) LivenessInterval(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "livenessInterval")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LivenessInterval is a free data retrieval call binding the contract method 0x38af7c5c.
+//
+// Solidity: function livenessInterval() view returns(uint256 livenessInterval_)
+func (_LivenessModule *LivenessModuleSession) LivenessInterval() (*big.Int, error) {
+	return _LivenessModule.Contract.LivenessInterval(&_LivenessModule.CallOpts)
+}
+
+// LivenessInterval is a free data retrieval call binding the contract method 0x38af7c5c.
+//
+// Solidity: function livenessInterval() view returns(uint256 livenessInterval_)
+func (_LivenessModule *LivenessModuleCallerSession) LivenessInterval() (*big.Int, error) {
+	return _LivenessModule.Contract.LivenessInterval(&_LivenessModule.CallOpts)
+}
+
+// MinOwners is a free data retrieval call binding the contract method 0x4b810d3e.
+//
+// Solidity: function minOwners() view returns(uint256 minOwners_)
+func (_LivenessModule *LivenessModuleCaller) MinOwners(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "minOwners")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinOwners is a free data retrieval call binding the contract method 0x4b810d3e.
+//
+// Solidity: function minOwners() view returns(uint256 minOwners_)
+func (_LivenessModule *LivenessModuleSession) MinOwners() (*big.Int, error) {
+	return _LivenessModule.Contract.MinOwners(&_LivenessModule.CallOpts)
+}
+
+// MinOwners is a free data retrieval call binding the contract method 0x4b810d3e.
+//
+// Solidity: function minOwners() view returns(uint256 minOwners_)
+func (_LivenessModule *LivenessModuleCallerSession) MinOwners() (*big.Int, error) {
+	return _LivenessModule.Contract.MinOwners(&_LivenessModule.CallOpts)
+}
+
+// OwnershipTransferredToFallback is a free data retrieval call binding the contract method 0x5b2e9c03.
+//
+// Solidity: function ownershipTransferredToFallback() view returns(bool)
+func (_LivenessModule *LivenessModuleCaller) OwnershipTransferredToFallback(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "ownershipTransferredToFallback")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// OwnershipTransferredToFallback is a free data retrieval call binding the contract method 0x5b2e9c03.
+//
+// Solidity: function ownershipTransferredToFallback() view returns(bool)
+func (_LivenessModule *LivenessModuleSession) OwnershipTransferredToFallback() (bool, error) {
+	return _LivenessModule.Contract.OwnershipTransferredToFallback(&_LivenessModule.CallOpts)
+}
+
+// OwnershipTransferredToFallback is a free data retrieval call binding the contract method 0x5b2e9c03.
+//
+// Solidity: function ownershipTransferredToFallback() view returns(bool)
+func (_LivenessModule *LivenessModuleCallerSession) OwnershipTransferredToFallback() (bool, error) {
+	return _LivenessModule.Contract.OwnershipTransferredToFallback(&_LivenessModule.CallOpts)
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessModule *LivenessModuleCaller) Safe(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "safe")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessModule *LivenessModuleSession) Safe() (common.Address, error) {
+	return _LivenessModule.Contract.Safe(&_LivenessModule.CallOpts)
+}
+
+// Safe is a free data retrieval call binding the contract method 0x186f0354.
+//
+// Solidity: function safe() view returns(address safe_)
+func (_LivenessModule *LivenessModuleCallerSession) Safe() (common.Address, error) {
+	return _LivenessModule.Contract.Safe(&_LivenessModule.CallOpts)
+}
+
+// ThresholdPercentage is a free data retrieval call binding the contract method 0x4ed2859e.
+//
+// Solidity: function thresholdPercentage() view returns(uint256 thresholdPercentage_)
+func (_LivenessModule *LivenessModuleCaller) ThresholdPercentage(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "thresholdPercentage")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ThresholdPercentage is a free data retrieval call binding the contract method 0x4ed2859e.
+//
+// Solidity: function thresholdPercentage() view returns(uint256 thresholdPercentage_)
+func (_LivenessModule *LivenessModuleSession) ThresholdPercentage() (*big.Int, error) {
+	return _LivenessModule.Contract.ThresholdPercentage(&_LivenessModule.CallOpts)
+}
+
+// ThresholdPercentage is a free data retrieval call binding the contract method 0x4ed2859e.
+//
+// Solidity: function thresholdPercentage() view returns(uint256 thresholdPercentage_)
+func (_LivenessModule *LivenessModuleCallerSession) ThresholdPercentage() (*big.Int, error) {
+	return _LivenessModule.Contract.ThresholdPercentage(&_LivenessModule.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessModule *LivenessModuleCaller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _LivenessModule.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessModule *LivenessModuleSession) Version() (string, error) {
+	return _LivenessModule.Contract.Version(&_LivenessModule.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_LivenessModule *LivenessModuleCallerSession) Version() (string, error) {
+	return _LivenessModule.Contract.Version(&_LivenessModule.CallOpts)
+}
+
+// RemoveOwners is a paid mutator transaction binding the contract method 0xf6ac15c4.
+//
+// Solidity: function removeOwners(address[] _previousOwners, address[] _ownersToRemove) returns()
+func (_LivenessModule *LivenessModuleTransactor) RemoveOwners(opts *bind.TransactOpts, _previousOwners []common.Address, _ownersToRemove []common.Address) (*types.Transaction, error) {
+	return _LivenessModule.contract.Transact(opts, "removeOwners", _previousOwners, _ownersToRemove)
+}
+
+// RemoveOwners is a paid mutator transaction binding the contract method 0xf6ac15c4.
+//
+// Solidity: function removeOwners(address[] _previousOwners, address[] _ownersToRemove) returns()
+func (_LivenessModule *LivenessModuleSession) RemoveOwners(_previousOwners []common.Address, _ownersToRemove []common.Address) (*types.Transaction, error) {
+	return _LivenessModule.Contract.RemoveOwners(&_LivenessModule.TransactOpts, _previousOwners, _ownersToRemove)
+}
+
+// RemoveOwners is a paid mutator transaction binding the contract method 0xf6ac15c4.
+//
+// Solidity: function removeOwners(address[] _previousOwners, address[] _ownersToRemove) returns()
+func (_LivenessModule *LivenessModuleTransactorSession) RemoveOwners(_previousOwners []common.Address, _ownersToRemove []common.Address) (*types.Transaction, error) {
+	return _LivenessModule.Contract.RemoveOwners(&_LivenessModule.TransactOpts, _previousOwners, _ownersToRemove)
+}
+
+// LivenessModuleOwnershipTransferredToFallbackIterator is returned from FilterOwnershipTransferredToFallback and is used to iterate over the raw logs and unpacked data for OwnershipTransferredToFallback events raised by the LivenessModule contract.
+type LivenessModuleOwnershipTransferredToFallbackIterator struct {
+	Event *LivenessModuleOwnershipTransferredToFallback // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *LivenessModuleOwnershipTransferredToFallbackIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(LivenessModuleOwnershipTransferredToFallback)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(LivenessModuleOwnershipTransferredToFallback)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *LivenessModuleOwnershipTransferredToFallbackIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *LivenessModuleOwnershipTransferredToFallbackIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// LivenessModuleOwnershipTransferredToFallback represents a OwnershipTransferredToFallback event raised by the LivenessModule contract.
+type LivenessModuleOwnershipTransferredToFallback struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferredToFallback is a free log retrieval operation binding the contract event 0x903af33ae084e750e45a10a53f61a69a4c5444f13a59954f5b3cf96e2862b5f4.
+//
+// Solidity: event OwnershipTransferredToFallback()
+func (_LivenessModule *LivenessModuleFilterer) FilterOwnershipTransferredToFallback(opts *bind.FilterOpts) (*LivenessModuleOwnershipTransferredToFallbackIterator, error) {
+
+	logs, sub, err := _LivenessModule.contract.FilterLogs(opts, "OwnershipTransferredToFallback")
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModuleOwnershipTransferredToFallbackIterator{contract: _LivenessModule.contract, event: "OwnershipTransferredToFallback", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferredToFallback is a free log subscription operation binding the contract event 0x903af33ae084e750e45a10a53f61a69a4c5444f13a59954f5b3cf96e2862b5f4.
+//
+// Solidity: event OwnershipTransferredToFallback()
+func (_LivenessModule *LivenessModuleFilterer) WatchOwnershipTransferredToFallback(opts *bind.WatchOpts, sink chan<- *LivenessModuleOwnershipTransferredToFallback) (event.Subscription, error) {
+
+	logs, sub, err := _LivenessModule.contract.WatchLogs(opts, "OwnershipTransferredToFallback")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(LivenessModuleOwnershipTransferredToFallback)
+				if err := _LivenessModule.contract.UnpackLog(event, "OwnershipTransferredToFallback", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferredToFallback is a log parse operation binding the contract event 0x903af33ae084e750e45a10a53f61a69a4c5444f13a59954f5b3cf96e2862b5f4.
+//
+// Solidity: event OwnershipTransferredToFallback()
+func (_LivenessModule *LivenessModuleFilterer) ParseOwnershipTransferredToFallback(log types.Log) (*LivenessModuleOwnershipTransferredToFallback, error) {
+	event := new(LivenessModuleOwnershipTransferredToFallback)
+	if err := _LivenessModule.contract.UnpackLog(event, "OwnershipTransferredToFallback", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// LivenessModuleRemovedOwnerIterator is returned from FilterRemovedOwner and is used to iterate over the raw logs and unpacked data for RemovedOwner events raised by the LivenessModule contract.
+type LivenessModuleRemovedOwnerIterator struct {
+	Event *LivenessModuleRemovedOwner // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *LivenessModuleRemovedOwnerIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(LivenessModuleRemovedOwner)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(LivenessModuleRemovedOwner)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *LivenessModuleRemovedOwnerIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *LivenessModuleRemovedOwnerIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// LivenessModuleRemovedOwner represents a RemovedOwner event raised by the LivenessModule contract.
+type LivenessModuleRemovedOwner struct {
+	Owner common.Address
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterRemovedOwner is a free log retrieval operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address indexed owner)
+func (_LivenessModule *LivenessModuleFilterer) FilterRemovedOwner(opts *bind.FilterOpts, owner []common.Address) (*LivenessModuleRemovedOwnerIterator, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _LivenessModule.contract.FilterLogs(opts, "RemovedOwner", ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &LivenessModuleRemovedOwnerIterator{contract: _LivenessModule.contract, event: "RemovedOwner", logs: logs, sub: sub}, nil
+}
+
+// WatchRemovedOwner is a free log subscription operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address indexed owner)
+func (_LivenessModule *LivenessModuleFilterer) WatchRemovedOwner(opts *bind.WatchOpts, sink chan<- *LivenessModuleRemovedOwner, owner []common.Address) (event.Subscription, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _LivenessModule.contract.WatchLogs(opts, "RemovedOwner", ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(LivenessModuleRemovedOwner)
+				if err := _LivenessModule.contract.UnpackLog(event, "RemovedOwner", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRemovedOwner is a log parse operation binding the contract event 0xf8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf.
+//
+// Solidity: event RemovedOwner(address indexed owner)
+func (_LivenessModule *LivenessModuleFilterer) ParseRemovedOwner(log types.Log) (*LivenessModuleRemovedOwner, error) {
+	event := new(LivenessModuleRemovedOwner)
+	if err := _LivenessModule.contract.UnpackLog(event, "RemovedOwner", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -28,7 +28,9 @@ type CLIConfig struct {
 	LoopIntervalMsec      uint64
 	StartingL1BlockHeight uint64
 
-	SafeAddress common.Address
+	LivenessModuleAddress common.Address
+	LivenessGuardAddress  common.Address
+	SafeAddress           common.Address
 }
 
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {

--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -2,8 +2,6 @@ package liveness_expiration
 
 import (
 	"errors"
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -48,12 +46,6 @@ func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 		return cfg, errors.New("no loop interval configured")
 	}
 
-	portalAddress := ctx.String(SafeAddressFlagName)
-	if !common.IsHexAddress(portalAddress) {
-		return cfg, fmt.Errorf("--%s is not a hex-encoded address", SafeAddressFlagName)
-	}
-	// cfg.OptimismPortalAddress = common.HexToAddress(portalAddress)
-
 	return cfg, nil
 }
 
@@ -67,7 +59,7 @@ func CLIFlags(envVar string) []cli.Flag {
 		},
 		&cli.Uint64Flag{
 			Name:     StartingL1BlockHeightFlagName,
-			Usage:    "Starting height to scan for events",
+			Usage:    "Starting height to scan for events (still not implemented for now.. The monitoring will start at the last block number)",
 			EnvVars:  opservice.PrefixEnvVar(envVar, "START_BLOCK_HEIGHT"),
 			Required: false,
 		},

--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -12,14 +12,14 @@ import (
 )
 
 const (
-	L1NodeURLFlagName = "l1.node.url"
-	L2NodeURLFlagName = "l2.node.url"
-
+	L1NodeURLFlagName             = "l1.node.url"
 	EventBlockRangeFlagName       = "event.block.range"
 	StartingL1BlockHeightFlagName = "start.block.height"
 
-	SafeAddressFlagName      = "safe.address"
-	LoopIntervalMsecFlagName = "loop.interval.msec"
+	SafeAddressFlagName           = "safe.address"
+	LivenessModuleAddressFlagName = "livenessmodule.address"
+	LivenessGuardAddressFlagName  = "livenessguard.address"
+	LoopIntervalMsecFlagName      = "loop.interval.msec"
 )
 
 type CLIConfig struct {
@@ -40,6 +40,8 @@ func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 		StartingL1BlockHeight: ctx.Uint64(StartingL1BlockHeightFlagName),
 		LoopIntervalMsec:      ctx.Uint64(LoopIntervalMsecFlagName),
 		SafeAddress:           common.HexToAddress(ctx.String(SafeAddressFlagName)),
+		LivenessModuleAddress: common.HexToAddress(ctx.String(LivenessModuleAddressFlagName)),
+		LivenessGuardAddress:  common.HexToAddress(ctx.String(LivenessGuardAddressFlagName)),
 	}
 
 	if cfg.LoopIntervalMsec == 0 {
@@ -70,9 +72,21 @@ func CLIFlags(envVar string) []cli.Flag {
 			Required: false,
 		},
 		&cli.StringFlag{
+			Name:     LivenessModuleAddressFlagName,
+			Usage:    "Address of the LivenessModuleAddress contract",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "LIVENESS_MODULE_ADDRESS"),
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     LivenessGuardAddressFlagName,
+			Usage:    "Address of the LivenessGuardAddress contract",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "LIVENESS_GUARD_ADDRESS"),
+			Required: true,
+		},
+		&cli.StringFlag{
 			Name:     SafeAddressFlagName,
 			Usage:    "Address of the safe contract",
-			EnvVars:  opservice.PrefixEnvVar(envVar, "OPTIMISM_PORTAL"),
+			EnvVars:  opservice.PrefixEnvVar(envVar, "SAFE_ADDRESS"),
 			Required: true,
 		},
 	}

--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -23,9 +23,7 @@ const (
 )
 
 type CLIConfig struct {
-	L1NodeURL string
-	L2NodeURL string
-
+	L1NodeURL             string
 	EventBlockRange       uint64
 	LoopIntervalMsec      uint64
 	StartingL1BlockHeight uint64
@@ -36,7 +34,6 @@ type CLIConfig struct {
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 	cfg := CLIConfig{
 		L1NodeURL:             ctx.String(L1NodeURLFlagName),
-		L2NodeURL:             ctx.String(L2NodeURLFlagName),
 		EventBlockRange:       ctx.Uint64(EventBlockRangeFlagName),
 		StartingL1BlockHeight: ctx.Uint64(StartingL1BlockHeightFlagName),
 		LoopIntervalMsec:      ctx.Uint64(LoopIntervalMsecFlagName),

--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -1,0 +1,80 @@
+package liveness_expiration
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	L1NodeURLFlagName = "l1.node.url"
+	L2NodeURLFlagName = "l2.node.url"
+
+	EventBlockRangeFlagName       = "event.block.range"
+	StartingL1BlockHeightFlagName = "start.block.height"
+
+	SafeAddressFlagName      = "safe.address"
+	LoopIntervalMsecFlagName = "loop.interval.msec"
+)
+
+type CLIConfig struct {
+	L1NodeURL string
+	L2NodeURL string
+
+	EventBlockRange       uint64
+	LoopIntervalMsec      uint64
+	StartingL1BlockHeight uint64
+
+	SafeAddress common.Address
+}
+
+func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
+	cfg := CLIConfig{
+		L1NodeURL:             ctx.String(L1NodeURLFlagName),
+		L2NodeURL:             ctx.String(L2NodeURLFlagName),
+		EventBlockRange:       ctx.Uint64(EventBlockRangeFlagName),
+		StartingL1BlockHeight: ctx.Uint64(StartingL1BlockHeightFlagName),
+		LoopIntervalMsec:      ctx.Uint64(LoopIntervalMsecFlagName),
+		SafeAddress:           common.HexToAddress(ctx.String(SafeAddressFlagName)),
+	}
+
+	if cfg.LoopIntervalMsec == 0 {
+		return cfg, errors.New("no loop interval configured")
+	}
+
+	portalAddress := ctx.String(SafeAddressFlagName)
+	if !common.IsHexAddress(portalAddress) {
+		return cfg, fmt.Errorf("--%s is not a hex-encoded address", SafeAddressFlagName)
+	}
+	// cfg.OptimismPortalAddress = common.HexToAddress(portalAddress)
+
+	return cfg, nil
+}
+
+func CLIFlags(envVar string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    L1NodeURLFlagName,
+			Usage:   "Node URL of L1 peer",
+			Value:   "127.0.0.1:8545",
+			EnvVars: opservice.PrefixEnvVar(envVar, "L1_NODE_URL"),
+		},
+		&cli.Uint64Flag{
+			Name:     StartingL1BlockHeightFlagName,
+			Usage:    "Starting height to scan for events",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "START_BLOCK_HEIGHT"),
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     SafeAddressFlagName,
+			Usage:    "Address of the safe contract",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "OPTIMISM_PORTAL"),
+			Required: true,
+		},
+	}
+}

--- a/op-monitorism/liveness_expiration/monitor.go
+++ b/op-monitorism/liveness_expiration/monitor.go
@@ -81,8 +81,6 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 		l1Client:          l1Client,
 		GnosisSafe:        GnosisSafe,
 		GnosisSafeAddress: cfg.SafeAddress,
-		// optimismPortal: optimismPortal,
-		// l2ToL1MP:       l2ToL1MP,
 
 		/** Metrics **/
 		highestBlockNumber: m.NewGaugeVec(prometheus.GaugeOpts{
@@ -116,7 +114,8 @@ func (m *Monitor) Run(ctx context.Context) {
 		m.log.Error("failed to query the method `GetOwners`", "err", err, "blockNumber", latestL1Height)
 		m.unexpectedRpcErrors.WithLabelValues("l1", "GetOwners").Inc()
 	}
-
+	// Liveness module mainnet  -> https://etherscan.io/address/0x0454092516c9A4d636d3CAfA1e82161376C8a748
+	// Liveness guard mainnet  ->  https://etherscan.io/address/0x24424336F04440b1c28685a38303aC33C9D14a25
 	// 1. call the safe.owners()
 	// 2. livenessGuard.lastLive(owner)
 	// 3. save the livenessInterval()

--- a/op-monitorism/liveness_expiration/monitor.go
+++ b/op-monitorism/liveness_expiration/monitor.go
@@ -1,0 +1,146 @@
+package liveness_expiration
+
+import (
+	"context"
+	"fmt"
+	// "math/big"
+
+	"github.com/ethereum-optimism/monitorism/op-monitorism/liveness_expiration/bindings"
+	// "github.com/ethereum/go-ethereum/accounts/abi/bind"
+	// "github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	// "github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+
+	// "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	MetricsNamespace = "two_step_monitor"
+
+	// event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
+	WithdrawalProvenEventABI = "WithdrawalProven(bytes32,address,address)"
+)
+
+var (
+	WithdrawalProvenEventABIHash = crypto.Keccak256Hash([]byte(WithdrawalProvenEventABI))
+)
+
+type Monitor struct {
+	log log.Logger
+
+	l1Client *ethclient.Client
+	l2Client *ethclient.Client
+
+	optimismPortalAddress common.Address
+	// optimismPortal        *bindings.OptimismPortalCaller
+	// l2ToL1MP              *bindings.L2ToL1MessagePasserCaller
+
+	maxBlockRange uint64
+	nextL1Height  uint64
+	GnosisSafe    *bindings.GnosisSafe
+
+	// metrics
+	highestBlockNumber     *prometheus.GaugeVec
+	isDetectingForgeries   prometheus.Gauge
+	withdrawalsValidated   prometheus.Counter
+	nodeConnectionFailures *prometheus.CounterVec
+}
+
+func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig) (*Monitor, error) {
+	log.Info("Starting the liveness expiration monitoring...")
+	l1Client, err := ethclient.Dial(cfg.L1NodeURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial l1: %w", err)
+	}
+	fmt.Println("Safe Address: ", cfg.SafeAddress)
+	if cfg.SafeAddress.Cmp(common.Address{}) == 0 {
+		return nil, fmt.Errorf("Incorrect SafeAddress specified is set to -> %s", cfg.SafeAddress)
+	}
+	GnosisSafe, err := bindings.NewGnosisSafe(cfg.SafeAddress, l1Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind to the GnosisSafe: %w", err)
+	}
+	owners, _ := GnosisSafe.GetOwners(nil)
+	fmt.Println(owners)
+	// l2Client, err := ethclient.Dial(cfg.L2NodeURL)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to dial l2: %w", err)
+	// }
+	//
+	// optimismPortal, err := bindings.NewOptimismPortalCaller(cfg.OptimismPortalAddress, l1Client)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to bind to the OptimismPortal: %w", err)
+	// }
+	// l2ToL1MP, err := bindings.NewL2ToL1MessagePasserCaller(predeploys.L2ToL1MessagePasserAddr, l2Client)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to bind to the OptimismPortal: %w", err)
+	// }
+
+	return &Monitor{
+		log: log,
+
+		l1Client:   l1Client,
+		GnosisSafe: GnosisSafe,
+		// optimismPortal: optimismPortal,
+		// l2ToL1MP:       l2ToL1MP,
+
+		/** Metrics **/
+		isDetectingForgeries: m.NewGauge(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "isDetectingForgeries",
+			Help:      "0 if state is ok. 1 if forged withdrawals are detected",
+		}),
+		withdrawalsValidated: m.NewCounter(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Name:      "withdrawalsValidated",
+			Help:      "number of withdrawals succesfully validated",
+		}),
+		highestBlockNumber: m.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "highestBlockNumber",
+			Help:      "observed l1 heights (checked and known)",
+		}, []string{"type"}),
+		nodeConnectionFailures: m.NewCounterVec(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Name:      "nodeConnectionFailures",
+			Help:      "number of times node connection has failed",
+		}, []string{"layer", "section"}),
+	}, nil
+}
+
+func (m *Monitor) Run(ctx context.Context) {
+	latestL1Height, _ := m.l1Client.BlockNumber(ctx)
+
+	m.log.Info("", "BlockNumber", latestL1Height)
+
+	// callOpts := bind.CallOpts{
+	// 	BlockNumber: big.NewInt(int64(latestL1Height)),
+	// }
+
+	GnosisSafe, err := m.GnosisSafe.GetOwners(nil)
+	if err != nil {
+		m.log.Error("failed to query latest block number", "err", err)
+	}
+
+	// 1. call the safe.owners()
+	// 2. livenessGuard.lastLive(owner)
+	// 3. save the livenessInterval()
+	// 4. Need to understand this => (lock.timestamp + BUFFER > lastLive(owner) + livenessInterval) == true
+
+	m.log.Info("", "Owners", GnosisSafe)
+	// Update markers
+	// m.nextL1Height = toBlockNumber + 1
+	// m.isDetectingForgeries.Set(0)
+	// m.highestBlockNumber.WithLabelValues("checked").Set(float64(toBlockNumber))
+}
+
+func (m *Monitor) Close(_ context.Context) error {
+	m.l1Client.Close()
+	return nil
+}

--- a/op-monitorism/multisig/README.md
+++ b/op-monitorism/multisig/README.md
@@ -1,0 +1,14 @@
+### Multisig Monitor
+
+The multisig monitor reports the paused status of the `OptimismPortal` contract. If set, the latest nonce of the configued `Safe` address. And also if set, the latest presigned nonce stored in One Password. The latest presigned nonce is identifyed by looking for items in the configued vault that follow a `ready-<nonce>.json` name. The highest nonce of this item name format is reported.
+
+- **NOTE**: In order to read from one password, the `OP_SERVICE_ACCOUNT_TOKEN` environment variable must be set granting the process permission to access the specified vault.
+
+```
+OPTIONS:
+   --l1.node.url value             [$MULTISIG_MON_L1_NODE_URL]       Node URL of L1 peer (default: "127.0.0.1:8545")
+   --optimismportal.address value  [$MULTISIG_MON_OPTIMISM_PORTAL]   Address of the OptimismPortal contract
+   --nickname value                [$MULTISIG_MON_NICKNAME]          Nickname of chain being monitored
+   --safe.address value            [$MULTISIG_MON_SAFE]              Address of the Safe contract
+   --op.vault value                [$MULTISIG_MON_1PASS_VAULT_NAME]  1Pass Vault name storing presigned safe txs following a 'ready-<nonce>.json' item name format
+```

--- a/op-monitorism/secrets/README.md
+++ b/op-monitorism/secrets/README.md
@@ -1,0 +1,16 @@
+### Secrets Monitor
+
+The secrets monitor takes a Drippie contract as a parameter and monitors for any drips within that contract that use the CheckSecrets dripcheck contract. CheckSecrets is a dripcheck that allows a drip to begin once a specific secret has been revealed (after a delay period) and cancels the drip if a second secret is revealed. It's important to monitor for these secrets being revealed as this could be a sign that the secret storage platform has been compromised and someone is attempting to exflitrate the ETH controlled by that drip.
+
+```
+OPTIONS:
+   --l1.node.url value         Node URL of L1 peer (default: "127.0.0.1:8545") [$SECRETS_MON_L1_NODE_URL]
+   --drippie.address value     Address of the Drippie contract [$SECRETS_MON_DRIPPIE]
+   --log.level value           The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
+   --log.format value          Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
+   --log.color                 Color the log output if in terminal mode (default: false) [$MONITORISM_LOG_COLOR]
+   --metrics.enabled           Enable the metrics server (default: false) [$MONITORISM_METRICS_ENABLED]
+   --metrics.addr value        Metrics listening address (default: "0.0.0.0") [$MONITORISM_METRICS_ADDR]
+   --metrics.port value        Metrics listening port (default: 7300) [$MONITORISM_METRICS_PORT]
+   --loop.interval.msec value  Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
+```


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Liveness expiration module is a monitoring dedicated for the safes.
Ensuring that owners that operates the safes are still actives enough.
To do so we are monitoring multiples metrics like: 
- `blockTimestamp`: The block Timestamp of the latest block number on L1.
- `highestBlockNumber`: The lastest block number height on L1.
- `lastLiveOfAOwner`: Get the last activities for a given safe owner on L1.  
- `intervalLiveness`: the *interval* (in seconds) from the `LivenessModule` on L1.  

![ab27497cea05fbd51b7b1c2ecde5bc69307ac0f27349f6bba4f3f21423116071](https://github.com/ethereum-optimism/monitorism/assets/23560242/af7a7e29-fff5-4df3-82f0-94c2f28fde84)

The alerts logic will be written into prometheus, thanks to the metrics we have right now. 