### PR TITLE
Remove the `LoopIntervalMsec` from liveness_expiration + withdrawals_mon.

### DIFF
--- a/op-monitorism/liveness_expiration/cli.go
+++ b/op-monitorism/liveness_expiration/cli.go
@@ -1,7 +1,6 @@
 package liveness_expiration
 
 import (
-	"errors"
 	"github.com/ethereum/go-ethereum/common"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -17,13 +16,11 @@ const (
 	SafeAddressFlagName           = "safe.address"
 	LivenessModuleAddressFlagName = "livenessmodule.address"
 	LivenessGuardAddressFlagName  = "livenessguard.address"
-	LoopIntervalMsecFlagName      = "loop.interval.msec"
 )
 
 type CLIConfig struct {
 	L1NodeURL             string
 	EventBlockRange       uint64
-	LoopIntervalMsec      uint64
 	StartingL1BlockHeight uint64
 
 	LivenessModuleAddress common.Address
@@ -36,14 +33,9 @@ func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 		L1NodeURL:             ctx.String(L1NodeURLFlagName),
 		EventBlockRange:       ctx.Uint64(EventBlockRangeFlagName),
 		StartingL1BlockHeight: ctx.Uint64(StartingL1BlockHeightFlagName),
-		LoopIntervalMsec:      ctx.Uint64(LoopIntervalMsecFlagName),
 		SafeAddress:           common.HexToAddress(ctx.String(SafeAddressFlagName)),
 		LivenessModuleAddress: common.HexToAddress(ctx.String(LivenessModuleAddressFlagName)),
 		LivenessGuardAddress:  common.HexToAddress(ctx.String(LivenessGuardAddressFlagName)),
-	}
-
-	if cfg.LoopIntervalMsec == 0 {
-		return cfg, errors.New("no loop interval configured")
 	}
 
 	return cfg, nil

--- a/op-monitorism/liveness_expiration/monitor.go
+++ b/op-monitorism/liveness_expiration/monitor.go
@@ -75,7 +75,6 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 	log.Info("", "Safe Address", cfg.SafeAddress)
 	log.Info("", "LivenessModuleAddress", cfg.LivenessModuleAddress)
 	log.Info("", "LivenessGuardAddress", cfg.LivenessGuardAddress)
-	log.Info("", "Interval", cfg.LoopIntervalMsec)
 	log.Info("", "L1RpcUrl", cfg.L1NodeURL)
 	log.Info("--------------------------- End of Infos -------------------------------------------------------")
 

--- a/op-monitorism/withdrawals/cli.go
+++ b/op-monitorism/withdrawals/cli.go
@@ -25,7 +25,6 @@ type CLIConfig struct {
 	L2NodeURL string
 
 	EventBlockRange       uint64
-	LoopIntervalMsec      uint64
 	StartingL1BlockHeight uint64
 
 	OptimismPortalAddress common.Address


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Remove the `LoopIntervalMsec` from _Liveness_expiration_ to be consistent with the rest of the code and also removed the unecessary argument left into _withdrawal_mon_.

**Tests**

Tested locally screesnshot below + CLI: 
**Liveness Expiration:** 
![1329d9f13daefcd29a02ef33604d54b18f8d43138001651cc0597d617299a982](https://github.com/user-attachments/assets/3e6b0f6f-5f50-4dc6-ae5a-15e6fd8fd170)
```shell
go run ../cmd/monitorism liveness_expiration --safe.address 0xc2819DC788505Aac350142A7A707BF9D03E3Bd03 --l1.node.url https://proxyd-l1-consensus.primary.mainnet.prod.oplabs.cloud --livenessmodule.address 0x0454092516c9A4d636d3CAfA1e82161376C8a748 --livenessguard.address 0x24424336F04440b1c28685a38303aC33C9D14a25 --loop.interval.msec 12000
```
**WIthdrawals:**
![41c7b0f6360bd101748285eb6713720ca849c58cff66bd2e9e3658af9f5f70d4](https://github.com/user-attachments/assets/4fc1d99e-4ea8-4c02-8632-45caa0a21ea4)

```shell
go run ../cmd/monitorism withdrawals  --l1.node.url https://proxyd-l1-consensus.primary.mainnet.prod.oplabs.cloud --loop.interval.msec 12000 --optimismportal.address 0xbEb5Fc579115071764c7423A4f12eDde41f106Ed --start.block.height 20522462 --l2.node.url https://proxyd-l2-consensus.primary.mainnet.prod.oplabs.cloud
```

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
