### PR TITLE
Add a onchain execution on forked network with Hardcoded values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ crytic-export
 
 bin
 op-defender/.air.toml
+op-defender/run.sh

--- a/op-defender/cmd/defender/cli.go
+++ b/op-defender/cmd/defender/cli.go
@@ -10,6 +10,7 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 
+	executor "github.com/ethereum-optimism/monitorism/op-defender/psp_executor"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/urfave/cli/v2"
@@ -57,7 +58,8 @@ func PSPExecutorMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp
 	}
 
 	metricsRegistry := opmetrics.NewRegistry()
-	defender_thread, err := psp_executor.NewDefender(ctx.Context, log, opmetrics.With(metricsRegistry), cfg)
+	executor := &executor.RealExecutor{}
+	defender_thread, err := psp_executor.NewDefender(ctx.Context, log, opmetrics.With(metricsRegistry), cfg, executor)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create psp_executor HTTP API service: %w", err)
 	}

--- a/op-defender/cmd/defender/cli.go
+++ b/op-defender/cmd/defender/cli.go
@@ -58,7 +58,7 @@ func PSPExecutorMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp
 	}
 
 	metricsRegistry := opmetrics.NewRegistry()
-	executor := &executor.RealExecutor{}
+	executor := &executor.DefenderExecutor{}
 	defender_thread, err := psp_executor.NewDefender(ctx.Context, log, opmetrics.With(metricsRegistry), cfg, executor)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create psp_executor HTTP API service: %w", err)

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -33,14 +33,27 @@ OPTIONS:
 
 To start the HTTP API service we can use the following oneliner command:
 ![f112841bad84c59ea3ed1ca380740f5694f553de8755b96b1a40ece4d1c26f81](https://github.com/user-attachments/assets/17235e99-bf25-40a5-af2c-a0d9990c6276)
+Settings of the HTTP API service:
+
+| Port                          | API Path             | HTTP Method |
+| ----------------------------- | -------------------- | ----------- |
+| 8080 (Default can be changed) | `/api/psp_execution` | POST        |
 
 ```shell
 go run ../cmd/defender psp_executor --privatekey XXXXXX --receiver.address 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF --rpc.url http://localhost:8545 --port.api 8080
 ```
 
-### cURL HTTP API
+### Metrics Server
 
-To use the HTTP API you can use the following `curl` command:
+| Option              | Description               | Default Value | Environment Variable          |
+| ------------------- | ------------------------- | ------------- | ----------------------------- |
+| `--metrics.enabled` | Enable the metrics server | `false`       | `$MONITORISM_METRICS_ENABLED` |
+| `--metrics.addr`    | Metrics listening address | `"0.0.0.0"`   | `$MONITORISM_METRICS_ADDR`    |
+| `--metrics.port`    | Metrics listening port    | `7300`        | `$MONITORISM_METRICS_PORT`    |
+
+### Usage of the HTTP API
+
+To use the HTTP API you can use the following `curl` command with the following fields:
 
 ![image](https://github.com/user-attachments/assets/3edc2ee5-6dfd-4872-9bc6-e3ead7444a96)
 

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -8,7 +8,7 @@ The service is designed to listen on a port and execute a PSP onchain when a req
 
 ## 1. Usage
 
-### 1.Run HTTP API service
+### 1 .Run HTTP API service
 
 To start the HTTP API service we can use the following oneliner command:
 ![f112841bad84c59ea3ed1ca380740f5694f553de8755b96b1a40ece4d1c26f81](https://github.com/user-attachments/assets/17235e99-bf25-40a5-af2c-a0d9990c6276)

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -6,7 +6,50 @@ The service is designed to listen on a port and execute a PSP onchain when a req
 
 ⚠️ The service has to use an authentication method before calling this API ⚠️
 
-### Options and Configuration
+## 1. Usage
+
+### 1.Run HTTP API service
+
+To start the HTTP API service we can use the following oneliner command:
+![f112841bad84c59ea3ed1ca380740f5694f553de8755b96b1a40ece4d1c26f81](https://github.com/user-attachments/assets/17235e99-bf25-40a5-af2c-a0d9990c6276)
+Settings of the HTTP API service:
+
+| Port                          | API Path             | HTTP Method |
+| ----------------------------- | -------------------- | ----------- |
+| 8080 (Default can be changed) | `/api/psp_execution` | POST        |
+
+```shell
+go run ../cmd/defender psp_executor --privatekey XXXXXX --receiver.address 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF --rpc.url http://localhost:8545 --port.api 8080
+```
+
+### 2. Request the HTTP API
+
+To use the HTTP API you can use the following `curl` command with the following fields:
+
+![image](https://github.com/user-attachments/assets/3edc2ee5-6dfd-4872-9bc6-e3ead7444a96)
+
+```bash
+curl -X POST http://${HTTP_API_PSP}:${PORT}/api/psp_execution \-H "Content-Type: application/json" \-d '{"pause": true, "timestamp": 1719432011, "operator": "Tom"}'
+```
+
+Explanation of the _mandatory_ fields:
+| Field | Description |
+| --------- | -------------------------------------------------------------------------------- |
+| pause | A boolean value indicating whether to pause (true) or unpause (false) the SuperchainConfig.|
+| timestamp | The Unix timestamp when the request is made. |
+| operator | The name or identifier of the person initiating the PSP execution. |
+
+### 3. Metrics Server
+
+To monitor the _PSPexecutor service_ the metrics server can be enabled. The metrics server will expose the metrics on the specified address and port.
+The metrics are using **Prometheus** and can be set with the following options:
+| Option | Description | Default Value | Environment Variable |
+| ------------------- | ------------------------- | ------------- | ----------------------------- |
+| `--metrics.enabled` | Enable the metrics server | `false` | `$MONITORISM_METRICS_ENABLED` |
+| `--metrics.addr` | Metrics listening address | `"0.0.0.0"` | `$MONITORISM_METRICS_ADDR` |
+| `--metrics.port` | Metrics listening port | `7300` | `$MONITORISM_METRICS_PORT` |
+
+### 4. Options and Configuration
 
 The current options are the following:
 
@@ -26,44 +69,3 @@ OPTIONS:
    --loop.interval.msec value  Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
    --help, -h                  show help
 ```
-
-## Usage
-
-### HTTP API service
-
-To start the HTTP API service we can use the following oneliner command:
-![f112841bad84c59ea3ed1ca380740f5694f553de8755b96b1a40ece4d1c26f81](https://github.com/user-attachments/assets/17235e99-bf25-40a5-af2c-a0d9990c6276)
-Settings of the HTTP API service:
-
-| Port                          | API Path             | HTTP Method |
-| ----------------------------- | -------------------- | ----------- |
-| 8080 (Default can be changed) | `/api/psp_execution` | POST        |
-
-```shell
-go run ../cmd/defender psp_executor --privatekey XXXXXX --receiver.address 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF --rpc.url http://localhost:8545 --port.api 8080
-```
-
-### Metrics Server
-
-| Option              | Description               | Default Value | Environment Variable          |
-| ------------------- | ------------------------- | ------------- | ----------------------------- |
-| `--metrics.enabled` | Enable the metrics server | `false`       | `$MONITORISM_METRICS_ENABLED` |
-| `--metrics.addr`    | Metrics listening address | `"0.0.0.0"`   | `$MONITORISM_METRICS_ADDR`    |
-| `--metrics.port`    | Metrics listening port    | `7300`        | `$MONITORISM_METRICS_PORT`    |
-
-### Usage of the HTTP API
-
-To use the HTTP API you can use the following `curl` command with the following fields:
-
-![image](https://github.com/user-attachments/assets/3edc2ee5-6dfd-4872-9bc6-e3ead7444a96)
-
-```bash
-curl -X POST http://${HTTP_API_PSP}:${PORT}/api/psp_execution \-H "Content-Type: application/json" \-d '{"pause": true, "timestamp": 1719432011, "operator": "Tom"}'
-```
-
-Explanation of the _mandatory_ fields:
-| Field | Description |
-| --------- | -------------------------------------------------------------------------------- |
-| pause | A boolean value indicating whether to pause (true) or unpause (false) the SuperchainConfig.|
-| timestamp | The Unix timestamp when the request is made. |
-| operator | The name or identifier of the person initiating the PSP execution. |

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -28,7 +28,9 @@ OPTIONS:
 ```
 
 ## Usage
+
 ### HTTP API service
+
 To start the HTTP API service we can use the following oneliner command:
 ![f112841bad84c59ea3ed1ca380740f5694f553de8755b96b1a40ece4d1c26f81](https://github.com/user-attachments/assets/17235e99-bf25-40a5-af2c-a0d9990c6276)
 
@@ -46,3 +48,9 @@ To use the HTTP API you can use the following `curl` command:
 curl -X POST http://${HTTP_API_PSP}:${PORT}/api/psp_execution \-H "Content-Type: application/json" \-d '{"pause": true, "timestamp": 1719432011, "operator": "Tom"}'
 ```
 
+Explanation of the _mandatory_ fields:
+| Field | Description |
+| --------- | -------------------------------------------------------------------------------- |
+| pause | A boolean value indicating whether to pause (true) or unpause (false) the system |
+| timestamp | The Unix timestamp when the request is made |
+| operator | The name or identifier of the person initiating the PSP execution |

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -2,9 +2,9 @@
 
 The PSP Executor service is a service designed to execute PSP onchain faster to increase our readiness and speed in case of incident response.
 
-The service is design to listen on a port and execute a PSP onchain when a request is received.
+The service is designed to listen on a port and execute a PSP onchain when a request is received.
 
-⚠️ The service as to use a authentification method before calling this API ⚠️
+⚠️ The service has to use an authentication method before calling this API ⚠️
 
 ### Options and Configuration
 
@@ -12,7 +12,7 @@ The current options are the following:
 
 ```
 OPTIONS:
-   --rpc-url value             Node URL of a peer (default: "http://127.0.0.1:8545") [$PSPEXECUTOR_MON_NODE_URL]
+   --rpc.url value             Node URL of a peer (default: "http://127.0.0.1:8545") [$PSPEXECUTOR_MON_NODE_URL]
    --privatekey value          Private key of the account that will issue the pause () [$PSPEXECUTOR_MON_PRIVATE_KEY]
    --receiver.address value    The receiver address of the pause request. [$PSPEXECUTOR_MON_RECEIVER_ADDRESS]
    --port.api value            Port of the API server you want to listen on (e.g. 8080). (default: "8080") [$PSPEXECUTOR_MON_PORT_API]
@@ -51,6 +51,6 @@ curl -X POST http://${HTTP_API_PSP}:${PORT}/api/psp_execution \-H "Content-Type:
 Explanation of the _mandatory_ fields:
 | Field | Description |
 | --------- | -------------------------------------------------------------------------------- |
-| pause | A boolean value indicating whether to pause (true) or unpause (false) the system |
-| timestamp | The Unix timestamp when the request is made |
-| operator | The name or identifier of the person initiating the PSP execution |
+| pause | A boolean value indicating whether to pause (true) or unpause (false) the SuperchainConfig.|
+| timestamp | The Unix timestamp when the request is made. |
+| operator | The name or identifier of the person initiating the PSP execution. |

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -164,7 +164,7 @@ func TestCheckAndReturnRPC(t *testing.T) {
 	tests := []struct {
 		name        string
 		rpcURL      string
-		expectedErr bool
+		expectErr bool
 	}{
 		{"Empty URL", "", true},
 		{"Production URL", "https://mainnet.infura.io", true},

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -162,8 +162,8 @@ func TestHandlePostMockFetch(t *testing.T) {
 // TestCheckAndReturnRPC tests that the CheckAndReturnRPC function returns the correct client or error for an incorrect URL provided.
 func TestCheckAndReturnRPC(t *testing.T) {
 	tests := []struct {
-		name        string
-		rpcURL      string
+		name      string
+		rpcURL    string
 		expectErr bool
 	}{
 		{"Empty URL", "", true},
@@ -174,11 +174,11 @@ func TestCheckAndReturnRPC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, err := CheckAndReturnRPC(tt.rpcURL)
-			if (err != nil) != tt.expectedErr {
-				t.Errorf("CheckAndReturnRPC() error = %v, expectedErr %v", err, tt.expectedErr)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CheckAndReturnRPC() error = %v, expectedErr %v", err, tt.expectErr)
 				return
 			}
-			if !tt.expectedErr && client == nil {
+			if !tt.expectErr && client == nil {
 				t.Errorf("CheckAndReturnRPC() returned nil client for valid URL")
 			}
 		})

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -162,9 +162,9 @@ func TestHandlePostMockFetch(t *testing.T) {
 // TestCheckAndReturnRPC tests that the CheckAndReturnRPC function returns the correct client or error for an incorrect URL provided.
 func TestCheckAndReturnRPC(t *testing.T) {
 	tests := []struct {
-		name    string
-		rpcURL  string
-		wantErr bool
+		name        string
+		rpcURL      string
+		expectedErr bool
 	}{
 		{"Empty URL", "", true},
 		{"Production URL", "https://mainnet.infura.io", true},
@@ -174,11 +174,11 @@ func TestCheckAndReturnRPC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, err := CheckAndReturnRPC(tt.rpcURL)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CheckAndReturnRPC() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("CheckAndReturnRPC() error = %v, expectedErr %v", err, tt.expectedErr)
 				return
 			}
-			if !tt.wantErr && client == nil {
+			if !tt.expectedErr && client == nil {
 				t.Errorf("CheckAndReturnRPC() returned nil client for valid URL")
 			}
 		})

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -17,7 +17,7 @@ import (
 type SimpleExecutor struct{}
 
 func (e *SimpleExecutor) FetchAndExecute(d *Defender) {
-	// Implement logic or return mock response
+	// Do nothing for now, for mocking purposes
 }
 
 // TestDefenderInitialization tests the initialization of the Defender struct
@@ -62,17 +62,17 @@ func TestDefenderInitialization(t *testing.T) {
 	// Add more checks as necessary for your application
 }
 
-// TestHandlePost tests the handlePost function for various scenarios
-func TestHandlePostE2E(t *testing.T) {
+// TestHandlePostMockFetch tests the handlePost function for various scenarios to check the result of the HTTP status code.
+func TestHandlePostMockFetch(t *testing.T) {
 	// Initialize the Defender with necessary mock or real components
-	logger := log.New()
-	// metricsfactory := prometheus.NewRegistry() // Use Prometheus for metrics
+	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
 	metricsRegistry := opmetrics.NewRegistry()
 	metricsfactory := opmetrics.With(metricsRegistry)
+	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 	executor := &SimpleExecutor{}
 	cfg := CLIConfig{
-		NodeUrl: "https://rpc.tenderly.co/fork/not_a_valid", // Example URL
-		portapi: "8080",
+		NodeURL: mockNodeUrl,
+		PortAPI: "8080",
 	}
 
 	defender, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -115,13 +115,13 @@ func TestHandlePostMockFetch(t *testing.T) {
 		{
 			path:           "/api/psp_execution",
 			name:           "Valid Request", // Check if the request is valid as expected return the 200 status code.
-			body:           `{"pause":true,"timestamp":1596240000,"operator":"0x123","calldata":"0xabc"}`,
+			body:           `{"pause":true,"timestamp":1596240000,"operator":"0x123"}`,
 			expectedStatus: http.StatusOK,
 		},
 		{
 			path:           "/api/psp_execution",
 			name:           "Invalid JSON", // Check if the JSON is invalid return the 400 status code.
-			body:           `{"pause":true, "timestamp":"invalid","operator":"0x123"}`,
+			body:           `{"pause":true, "timestamp":"invalid","operator":}`,
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
@@ -133,7 +133,7 @@ func TestHandlePostMockFetch(t *testing.T) {
 		{
 			path:           "/api/",
 			name:           "Incorrect Path Fields", // Check if the path is incorrect return the 404 status code.
-			body:           `{"pause":true,"timestamp":1596240000,"operator":"0x123","calldata":"0xabc"}`,
+			body:           `{"pause":true,"timestamp":1596240000,"operator":"0x123"}`,
 			expectedStatus: http.StatusNotFound,
 		},
 	}

--- a/op-defender/psp_executor/cli.go
+++ b/op-defender/psp_executor/cli.go
@@ -17,15 +17,15 @@ const (
 )
 
 type CLIConfig struct {
-	NodeUrl         string
+	NodeURL         string
 	privatekeyflag  string
-	portapi         string
-	receiverAddress string
-	hexString       string
+	PortAPI         string
+	ReceiverAddress string
+	HexString       string
 }
 
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
-	cfg := CLIConfig{NodeUrl: ctx.String(NodeURLFlagName)}
+	cfg := CLIConfig{NodeURL: ctx.String(NodeURLFlagName)}
 	if len(PrivateKeyFlagName) == 0 {
 		return cfg, fmt.Errorf("must have a PrivateKeyFlagName set to execute the pause on mainnet")
 	}
@@ -33,16 +33,15 @@ func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 	if len(PortAPIFlagName) == 0 {
 		return cfg, fmt.Errorf("must have a PortAPIFlagName set to execute the pause on mainnet")
 	}
-	cfg.receiverAddress = ctx.String(ReceiverAddressFlagName)
+	cfg.PortAPI = ctx.String(PortAPIFlagName)
 	if len(ReceiverAddressFlagName) == 0 {
 		return cfg, fmt.Errorf("must have a ReceiverAddressFlagName set to receive the pause on mainnet.")
 	}
-
-	cfg.hexString = ctx.String(DataFlagName)
+	cfg.ReceiverAddress = ctx.String(ReceiverAddressFlagName)
 	if len(DataFlagName) == 0 {
 		return cfg, fmt.Errorf("must have a `data` set to execute the calldata on mainnet.")
 	}
-	cfg.portapi = ctx.String(PortAPIFlagName)
+	cfg.HexString = ctx.String(DataFlagName)
 	return cfg, nil
 }
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -39,7 +39,7 @@ const (
 	LocalhostRPC     = "http://localhost:8545"
 )
 
-type RealExecutor struct{}
+type DefenderExecutor struct{}
 
 type Executor interface {
 	FetchAndExecute(d *Defender)
@@ -93,19 +93,18 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 // NewAPI creates a new HTTP API Server for the PSP Executor and starts listening on the specified port from the args passed.
 func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig, executor Executor) (*Defender, error) {
 	// Set the route and handler function for the `/api/psp_execution` endpoint.
-	l1client, err := CheckAndReturnRPC(cfg.NodeUrl)
+	l1client, err := CheckAndReturnRPC(cfg.NodeURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch l1 RPC: %w", err)
 	}
-
-	if cfg.portapi == "" {
+	if cfg.PortAPI == "" {
 		return nil, fmt.Errorf("port.api is not set.")
 	}
 
 	defender := &Defender{
 		log:      log,
 		l1Client: l1client,
-		port:     cfg.portapi,
+		port:     cfg.PortAPI,
 		executor: executor,
 	}
 
@@ -115,7 +114,7 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 	return defender, nil
 }
 
-func (e *RealExecutor) FetchAndExecute(d *Defender) {
+func (e *DefenderExecutor) FetchAndExecute(d *Defender) {
 	ctx := context.Background() // Consider passing context through method parameters
 	privateKey, err := FetchPrivateKeyInGcp()
 	if err != nil {
@@ -161,7 +160,7 @@ func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
 	client, err := ethclient.Dial(rpc_url)
 	if err != nil {
 
-		log.Crit("Failed to connect to the Ethereum client: %v", err.Error())
+		log.Crit("Failed to connect to the Ethereum client", "error", err)
 	}
 	return client, nil
 }

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -119,7 +119,7 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 }
 
 // FetchAndExecute() will fetch the PSP and execute it this onchain.
-// For now, the function is now fully implemented and will make a dummy transaction on chain (see `pspExecutionOnChain()`).
+// For now, the function is not fully implemented and will make a dummy transaction on chain (see `pspExecutionOnChain()`).
 // In the future, the function will fetch the PSPs from a secret file and execute it onchain through a EVM transaction.
 func (e *DefenderExecutor) FetchAndExecute(d *Defender) {
 	ctx := context.Background()

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -39,11 +39,6 @@ const (
 	LocalhostRPC     = "http://localhost:8545"
 )
 
-type Account struct {
-	Address  common.Address
-	Nickname string
-}
-
 type Defender struct {
 	log                     log.Logger
 	port                    string
@@ -71,7 +66,6 @@ type RequestData struct {
 // handlePost handles POST requests and processes the JSON body
 func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 	var data RequestData
-	println("Received HTTP request", "method", r.Method, "url", r.URL)
 	//log the HTTP message and print the body inside the logs for debugging purposes.
 	d.log.Info("Received HTTP request", "method", r.Method, "url", r.URL)
 	// Decode the JSON body into the struct
@@ -103,9 +97,7 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 
 	defender.router = mux.NewRouter()
 	defender.router.HandleFunc("/api/psp_execution", defender.handlePost).Methods("POST")
-
 	defender.log.Info("Starting HTTP JSON API PSP Execution server...", "port", defender.port)
-	defender.log.Info("rpc.url", cfg.NodeUrl)
 	return defender, nil
 }
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -75,8 +75,7 @@ func handlePost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	// return HTTP code 511 for the first PR.
-	http.Error(w, "Network Authentication Required", 511)
+	FetchAndExecute()
 	return
 }
 
@@ -160,21 +159,20 @@ func FetchPSPInGCP() (string, string, []byte, error) { //superchainconfig_addres
 
 // PSPexecution(): PSPExecutionOnChain is a core function that will check that status of the superchain is not paused and then send onchain transaction to pause the superchain.
 func PspExecutionOnChain(ctx context.Context, l1client *ethclient.Client, superchainconfig_address string, privatekey string, safe_address string, data []byte) {
-	log.Info("PSP Execution Pause")
 	pause_before_transaction := checkPauseStatus(ctx, l1client, superchainconfig_address)
 	if pause_before_transaction {
 		log.Crit("The SuperChainConfig is already paused! Exiting the program.")
 	}
-	log.Info("Before the transaction the status of the `pause` is set to: ", pause_before_transaction)
+	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
 	txHash, err := sendTransaction(l1client, privatekey, safe_address, big.NewInt(1), data) // 1 wei
 	if err != nil {
 		log.Crit("Failed to send transaction:", "error", err)
 	}
 
-	log.Info("Transaction sent! Tx Hash: %s\n", txHash)
+	log.Info("Transaction sent!", "TxHash", txHash)
 
 	pause_after_transaction := checkPauseStatus(ctx, l1client, superchainconfig_address)
-	log.Info("After the transaction the status of the `pause` is set to: ", pause_after_transaction)
+	log.Info("[After Transaction] status of the pause()", "pause", pause_after_transaction)
 
 }
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -44,7 +44,7 @@ type DefenderExecutor struct{}
 
 // Executor is an interface that defines the FetchAndExecute method.
 type Executor interface {
-	FetchAndExecute(d *Defender)
+	FetchAndExecute(d *Defender) // For doc see the `FetchAndExecute()` function.
 }
 
 // Defender is a struct that represents the Defender API server.
@@ -71,7 +71,6 @@ type RequestData struct {
 	Pause     bool   `json:"pause"`
 	Timestamp int64  `json:"timestamp"`
 	Operator  string `json:"operator"`
-	Calldata  string `json:"calldata"` //temporary field as the calldata will be fetched from the GCP in the future (so will be removed in the future PR).
 }
 
 // handlePost handles POST requests and processes the JSON body
@@ -85,7 +84,7 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	//check that all the fields are set
-	if data.Pause == false || data.Timestamp == 0 || data.Operator == "" || data.Calldata == "" {
+	if data.Pause == false || data.Timestamp == 0 || data.Operator == "" {
 		http.Error(w, "Missing fields in the request", http.StatusBadRequest)
 		return
 	}
@@ -120,7 +119,8 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 }
 
 // FetchAndExecute() will fetch the PSP and execute it this onchain.
-// For now the function is now fully implemented and will make a dummy transaction on chain (see `pspExecutionOnChain()`).
+// For now, the function is now fully implemented and will make a dummy transaction on chain (see `pspExecutionOnChain()`).
+// In the future, the function will fetch the PSPs from a secret file and execute it onchain through a EVM transaction.
 func (e *DefenderExecutor) FetchAndExecute(d *Defender) {
 	ctx := context.Background()
 	privateKey, err := FetchPrivateKeyInGcp()

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -39,12 +39,15 @@ const (
 	LocalhostRPC     = "http://localhost:8545"
 )
 
+// DefenderExecutor is a struct that implements the Executor interface.
 type DefenderExecutor struct{}
 
+// Executor is an interface that defines the FetchAndExecute method.
 type Executor interface {
 	FetchAndExecute(d *Defender)
 }
 
+// Defender is a struct that represents the Defender API server.
 type Defender struct {
 	log                     log.Logger
 	port                    string
@@ -57,12 +60,13 @@ type Defender struct {
 	unexpectedRpcErrors *prometheus.CounterVec
 }
 
-// Define a struct that represents the data structure of your response
+// Define a struct that represents the data structure of your response through the HTTP API.
 type Response struct {
 	Message string `json:"message"`
 	Status  int    `json:"status"`
 }
 
+// Define a struct that represents the data structure of your request through the HTTP API.
 type RequestData struct {
 	Pause     bool   `json:"pause"`
 	Timestamp int64  `json:"timestamp"`
@@ -115,6 +119,8 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 	return defender, nil
 }
 
+// FetchAndExecute() will fetch the PSP and execute it this onchain.
+// For now the function is now fully implemented and will make a dummy transaction on chain (see `pspExecutionOnChain()`).
 func (e *DefenderExecutor) FetchAndExecute(d *Defender) {
 	ctx := context.Background()
 	privateKey, err := FetchPrivateKeyInGcp()
@@ -150,14 +156,13 @@ func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
 
 // FetchPrivateKey() will fetch the privatekey of the account that will execute the pause (from the GCP secret manager).
 func FetchPrivateKeyInGcp() (string, error) {
-	return "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6", nil // Mock with a well-known private key from test test ... test junk derivation (9).
+	return "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6", nil // Mock with a well-known private key from "test test ... test junk" derivation (9).
 }
 
 // FetchPSPInGCP() will fetch the correct PSPs into GCP and return the Data.
-func FetchPSPInGCP() (string, string, []byte, error) { //superchainconfig_address, safe_address, data, error
-	// need to fetch check first the nonce with the same method with `checkPauseStatus` and then return the data for this PSP.
-
-	return "0xC2Be75506d5724086DEB7245bd260Cc9753911Be", "0x4141414142424242414141414242424241414141", []byte{0x41, 0x42, 0x43}, nil //errors.New("Not implemented") mock with simple value to make a call on L1.
+func FetchPSPInGCP() (string, string, []byte, error) {
+	//In the future, we need to check first the nonce and then `checkPauseStatus` and then return the data for the latest PSPs.
+	return "0xC2Be75506d5724086DEB7245bd260Cc9753911Be", "0x4141414142424242414141414242424241414141", []byte{0x41, 0x42, 0x43}, nil
 }
 
 // PSPexecution(): PSPExecutionOnChain is a core function that will check that status of the superchain is not paused and then send onchain transaction to pause the superchain.
@@ -179,6 +184,7 @@ func PspExecutionOnChain(ctx context.Context, l1client *ethclient.Client, superc
 
 }
 
+// Run() will start the Defender API server and block the thread.
 func (d *Defender) Run(ctx context.Context) {
 	err := http.ListenAndServe(":"+d.port, d.router) // Start the HTTP server blocking thread for now.
 	if err != nil {
@@ -186,6 +192,7 @@ func (d *Defender) Run(ctx context.Context) {
 	}
 }
 
+// Close() will close the Defender API server and the L1 client.
 func (d *Defender) Close(_ context.Context) error {
 	d.l1Client.Close() //close the L1 client.
 	return nil


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A PR to execute a hard-coded transaction (sent 1wei to  `0x4141414142424242414141414242424241414141` with data=`0x414243`) on forked L1 on Sepolia using a well known privatekey.
 
![9ec733437aca03061ec4bdf188b23c401b126cf60752d6988deb0f015a1b55e2](https://github.com/user-attachments/assets/493560db-9f58-45cb-a14b-2785fd476567)


From a simple cURL will trigger the onchain execution. 

![CleanShot 2024-08-29 at 13 33 16@2x](https://github.com/user-attachments/assets/f35dc9b1-e307-4100-a873-3f0382ed15fc)


We can see that the [transaction on tenderly](https://dashboard.tenderly.co/explorer/fork/82c36ace-0b2f-40a5-82d1-25e085a5d82b/simulation/eda7acc6-b598-4cbf-8035-8c42e0064a79) is a simple movemement of 1 wei to `0x4141414142424242414141414242424241414141` with calldata=`0x414243`.
<img width="1637" alt="image" src="https://github.com/user-attachments/assets/61975626-6abe-433c-825a-85b0e699fb65">


**Tests**

I made some tests using the HTTP API directly using: 
```bash
curl -X POST http://localhost:8080/api/psp_execution \-H "Content-Type: application/json" \-d '{"pause": true, "timestamp": 1719432011, "operator": "Tom"}'
```

To make better testing, I had to create a mocking interface:
```go
type SimpleExecutor struct{}

func (e *SimpleExecutor) FetchAndExecute(d *Defender) {
	// Do nothing for now, for mocking purposes
}
```
To achieve this, I have added a `executor` to the defender object for helping us in the future for mocking the results.

I haved added multiples unit tests in the file `api_test.go` for the new created functions. 
- `TestHTTPServerHasOnlyPSPExecutionRoute()`: This ensure the API HTTP is not listenning on another methods or other routes. To make sure no undesired HTTP requests can be crafted on unknown method or path. 
- `TestDefenderInitialization()`: This ensure we can create a _defender_ with a mock `FetchAndExecute()` method.  
- `TestCheckAndReturnRPC()`: This make sure that the RPC ur is  correct and _valid_ RPC. This is particular useful for during the development part to not send transaction accidentally on undesired network.  
- `TestHandlePostMockFetch()`: This test the HTTP status code result to ensure malformed HTTP request return the correct status code. 

```bash
=== RUN   TestHTTPServerHasOnlyPSPExecutionRoute
--- PASS: TestHTTPServerHasOnlyPSPExecutionRoute (0.00s)
=== RUN   TestDefenderInitialization
--- PASS: TestDefenderInitialization (0.00s)
=== RUN   TestHandlePostMockFetch
=== RUN   TestHandlePostMockFetch/Valid_Request
=== RUN   TestHandlePostMockFetch/Invalid_JSON
=== RUN   TestHandlePostMockFetch/Missing_Fields
=== RUN   TestHandlePostMockFetch/Incorrect_Path_Fields
--- PASS: TestHandlePostMockFetch (0.00s)
    --- PASS: TestHandlePostMockFetch/Valid_Request (0.00s)
    --- PASS: TestHandlePostMockFetch/Invalid_JSON (0.00s)
    --- PASS: TestHandlePostMockFetch/Missing_Fields (0.00s)
    --- PASS: TestHandlePostMockFetch/Incorrect_Path_Fields (0.00s)
=== RUN   TestCheckAndReturnRPC
=== RUN   TestCheckAndReturnRPC/Empty_URL
=== RUN   TestCheckAndReturnRPC/Production_URL
=== RUN   TestCheckAndReturnRPC/Valid_Tenderly_Fork_URL
--- PASS: TestCheckAndReturnRPC (0.00s)
    --- PASS: TestCheckAndReturnRPC/Empty_URL (0.00s)
    --- PASS: TestCheckAndReturnRPC/Production_URL (0.00s)
    --- PASS: TestCheckAndReturnRPC/Valid_Tenderly_Fork_URL (0.00s)
PASS
ok      github.com/ethereum-optimism/monitorism/op-defender/psp_executor        0.924s
```

**Additional context**
This is the PR N°3, after this one will make 2 PRs again to complete the psp_executor. 
Worth noting there is multiples `@todo` tags that would be fixed in the future PRs. 

I have also improve the current README with the current features. 