### PR TITLE
Refactoring + improve logging and add a Get method `api/healthcheck`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ crytic-export
 bin
 op-defender/.air.toml
 op-defender/run.sh
+op-defender/tmp

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -35,8 +35,8 @@ func GeneratePrivatekey(size int) string {
 	return "0x" + privateKeyHex
 }
 
-// TestHTTPServerHasOnlyPSPExecutionRoute tests if the HTTP server has only one route with "/api/psp_execution" path and "POST" method.
-func TestHTTPServerHasOnlyPSPExecutionRoute(t *testing.T) {
+// TestHTTPServerHasCorrectRoute() tests if the HTTP server has the correct route with "/api/psp_execution" path and "POST" method and the "/api/healthcheck" path and "GET" method.
+func TestHTTPServerHasCorrectRoute(t *testing.T) {
 	// Mock dependencies or create real ones depending on your test needs
 	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
 	executor := &SimpleExecutor{}
@@ -84,6 +84,7 @@ func TestHTTPServerHasOnlyPSPExecutionRoute(t *testing.T) {
 		}
 	}
 }
+
 // TestDefenderInitialization tests the initialization of the Defender struct with mock dependencies.
 func TestDefenderInitialization(t *testing.T) {
 	// Mock dependencies or create real ones depending on your test needs

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -54,38 +54,36 @@ func TestHTTPServerHasOnlyPSPExecutionRoute(t *testing.T) {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
 
-	// We Check if the router has only one route
+	// We Check if the router has two routes
 	routeCount := 0
-	expectedPath := "/api/psp_execution"
-	expectedMethod := "POST"
-	var foundRoute *mux.Route
+	expectedRoutes := map[string]string{
+		"/api/psp_execution": "POST",
+		"/api/healthcheck":   "GET",
+	}
+	foundRoutes := make(map[string]string)
 
 	defender.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		routeCount++
-		foundRoute = route
+		path, _ := route.GetPathTemplate()
+		methods, _ := route.GetMethods()
+		if len(methods) > 0 {
+			foundRoutes[path] = methods[0]
+			routeCount++
+		}
 		return nil
 	})
 
-	if routeCount != 1 {
-		t.Errorf("Expected 1 route, but got %d", routeCount)
+	if routeCount != 2 {
+		t.Errorf("Expected 2 routes, but got %d", routeCount)
 	}
 
-	if foundRoute != nil {
-		path, _ := foundRoute.GetPathTemplate()
-		methods, _ := foundRoute.GetMethods()
-
-		if path != expectedPath {
-			t.Errorf("Expected path %s, but got %s", expectedPath, path)
+	for path, method := range expectedRoutes {
+		if foundMethod, ok := foundRoutes[path]; !ok {
+			t.Errorf("Expected route %s not found", path)
+		} else if foundMethod != method {
+			t.Errorf("Expected method %s for path %s, but got %s", method, path, foundMethod)
 		}
-
-		if len(methods) != 1 || methods[0] != expectedMethod {
-			t.Errorf("Expected method %s, but got %v", expectedMethod, methods)
-		}
-	} else {
-		t.Error("No route found")
 	}
 }
-
 // TestDefenderInitialization tests the initialization of the Defender struct with mock dependencies.
 func TestDefenderInitialization(t *testing.T) {
 	// Mock dependencies or create real ones depending on your test needs

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -135,6 +135,13 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 // NewAPI creates a new HTTP API Server for the PSP Executor and starts listening on the specified port from the args passed.
 func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig, executor Executor) (*Defender, error) {
 	// Set the route and handler function for the `/api/psp_execution` endpoint.
+	println("============================ Configuration Info ================================")
+	log.Info("cfg.nodeurl", "cfg.nodeurl", cfg.NodeURL)
+	log.Info("cfg.portapi", "cfg.portapi", cfg.PortAPI)
+	log.Info("cfg.receiveraddress", "cfg.receiveraddress", cfg.ReceiverAddress)
+	log.Info("cfg.hexstring", "cfg.hexstring", cfg.HexString)
+	println("============================================================================")
+
 	l1client, err := CheckAndReturnRPC(cfg.NodeURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch l1 RPC: %w", err)
@@ -155,13 +162,11 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 		executor:   executor,
 		privatekey: privatekey,
 	}
-
 	defender.router = mux.NewRouter()
 	defender.router.HandleFunc("/api/psp_execution", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 1048576) // Limit payload to 1MB
 		defender.handlePost(w, r)
 	}).Methods("POST")
-	defender.log.Info("Starting HTTP JSON API PSP Execution server...", "port", defender.port)
 	return defender, nil
 }
 
@@ -180,6 +185,7 @@ func (e *DefenderExecutor) FetchAndExecute(d *Defender) {
 
 // CheckAndReturnRPC() will return the L1 client based on the RPC provided in the config and ensure that the RPC is not production one.
 func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
+
 	if rpc_url == "" {
 		return nil, fmt.Errorf("rpc.url is not set.")
 	}
@@ -189,7 +195,6 @@ func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
 
 	client, err := ethclient.Dial(rpc_url)
 	if err != nil {
-
 		log.Crit("Failed to connect to the Ethereum client", "error", err)
 	}
 	return client, nil

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -327,13 +327,16 @@ func sendTransaction(client *ethclient.Client, privateKeyStr string, toAddressSt
 // checkPauseStatus(): Is a function made for checking the pause status of the SuperChainConfigAddress
 func checkPauseStatus(ctx context.Context, l1client *ethclient.Client, SuperChainConfigAddress string) bool {
 	// Get the contract instance
-	contractAddress := common.HexToAddress(SuperChainConfigAddress)
-	optimismPortal, err := bindings.NewSuperchainConfig(contractAddress, l1client)
+	log.Info("SuperChainConfigAddress", "SuperChainConfigAddress", SuperChainConfigAddress)
+	log.Info("l1client", "l1client", l1client)
+	superchain, err := bindings.NewSuperchainConfig(common.HexToAddress(SuperChainConfigAddress), l1client)
+
+	log.Info("superchain infos", "superchain address", superchain)
 	if err != nil {
 		log.Crit("Failed to create SuperChainConfig instance: %v", err)
 	}
 
-	paused, err := optimismPortal.Paused(&bind.CallOpts{Context: ctx})
+	paused, err := superchain.Paused(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		log.Error("failed to query OptimismPortal paused status", "err", err)
 		return false

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -329,16 +329,16 @@ func checkPauseStatus(ctx context.Context, l1client *ethclient.Client, SuperChai
 	// Get the contract instance
 	log.Info("SuperChainConfigAddress", "SuperChainConfigAddress", SuperChainConfigAddress)
 	log.Info("l1client", "l1client", l1client)
-	superchain, err := bindings.NewSuperchainConfig(common.HexToAddress(SuperChainConfigAddress), l1client)
+	superchainconfig, err := bindings.NewSuperchainConfig(common.HexToAddress(SuperChainConfigAddress), l1client)
 
-	log.Info("superchain infos", "superchain address", superchain)
+	log.Info("superchainconfig", "superchainconfig address", superchainconfig)
 	if err != nil {
-		log.Crit("Failed to create SuperChainConfig instance: %v", err)
+		log.Crit("failed to create superchainconfig instance", "error", err)
 	}
 
-	paused, err := superchain.Paused(&bind.CallOpts{Context: ctx})
+	paused, err := superchainconfig.Paused(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		log.Error("failed to query OptimismPortal paused status", "err", err)
+		log.Error("failed to query superchainconfig paused status", "error", err)
 		return false
 	}
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -173,7 +173,7 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 		r.Body = http.MaxBytesReader(w, r.Body, 1048576) // Limit payload to 1MB
 		defender.handlePost(w, r)
 	}).Methods("POST")
-	defender.router.HandleFunc("/healthcheck", defender.handleHealthCheck).Methods("GET")
+	defender.router.HandleFunc("/api/healthcheck", defender.handleHealthCheck).Methods("GET")
 	return defender, nil
 }
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -75,6 +75,11 @@ type RequestData struct {
 	Operator  string `json:"operator"`
 }
 
+// handleHealthCheck is a GET method that returns the health status of the Defender
+func (d *Defender) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
+}
+
 // handlePost handles POST requests and processes the JSON body
 func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 	// Decode the JSON body into a map
@@ -142,7 +147,8 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 	log.Info("cfg.hexstring", "cfg.hexstring", cfg.HexString)
 	println("============================================================================")
 
-	l1client, err := CheckAndReturnRPC(cfg.NodeURL)
+	l1client, err := CheckAndReturnRPC(cfg.NodeURL) //@todo: Need to check if the latest blocknumber returned is 0.
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch l1 RPC: %w", err)
 	}
@@ -167,6 +173,7 @@ func NewDefender(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLI
 		r.Body = http.MaxBytesReader(w, r.Body, 1048576) // Limit payload to 1MB
 		defender.handlePost(w, r)
 	}).Methods("POST")
+	defender.router.HandleFunc("/healthcheck", defender.handleHealthCheck).Methods("GET")
 	return defender, nil
 }
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -245,13 +245,11 @@ func FetchPSPInGCP() (string, string, []byte, error) {
 
 // PSPexecution(): PSPExecutionOnChain is a core function that will check that status of the superchain is not paused and then send onchain transaction to pause the superchain.
 func PspExecutionOnChain(ctx context.Context, l1client *ethclient.Client, superchainconfig_address string, privatekey string, safe_address string, data []byte) {
-	blocknumber, err := l1client.BlockNumber(ctx)
-	log.Info("", "block number", blocknumber)
 	pause_before_transaction := checkPauseStatus(ctx, l1client, superchainconfig_address)
 	if pause_before_transaction {
 		log.Crit("The SuperChainConfig is already paused! Exiting the program.")
 	}
-	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
+	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction, "superchainconfig_address", superchainconfig_address, "safe_address", safe_address)
 	txHash, err := sendTransaction(l1client, privatekey, safe_address, big.NewInt(1), data) // 1 wei
 	if err != nil {
 		log.Crit("Failed to send transaction:", "error", err)
@@ -341,11 +339,8 @@ func sendTransaction(client *ethclient.Client, privateKeyStr string, toAddressSt
 // checkPauseStatus(): Is a function made for checking the pause status of the SuperChainConfigAddress
 func checkPauseStatus(ctx context.Context, l1client *ethclient.Client, SuperChainConfigAddress string) bool {
 	// Get the contract instance
-	log.Info("SuperChainConfigAddress", "SuperChainConfigAddress", SuperChainConfigAddress)
-	log.Info("l1client", "l1client", l1client)
 	superchainconfig, err := bindings.NewSuperchainConfig(common.HexToAddress(SuperChainConfigAddress), l1client)
 
-	log.Info("superchainconfig", "superchainconfig address", superchainconfig)
 	if err != nil {
 		log.Crit("failed to create superchainconfig instance", "error", err)
 	}

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -233,6 +233,8 @@ func FetchPSPInGCP() (string, string, []byte, error) {
 
 // PSPexecution(): PSPExecutionOnChain is a core function that will check that status of the superchain is not paused and then send onchain transaction to pause the superchain.
 func PspExecutionOnChain(ctx context.Context, l1client *ethclient.Client, superchainconfig_address string, privatekey string, safe_address string, data []byte) {
+	blocknumber, err := l1client.BlockNumber(ctx)
+	log.Info("", "block number", blocknumber)
 	pause_before_transaction := checkPauseStatus(ctx, l1client, superchainconfig_address)
 	if pause_before_transaction {
 		log.Crit("The SuperChainConfig is already paused! Exiting the program.")


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This is small PR to refactor the function `checkPauseStatus()` to add a better logging + better name convention.

This also include a new GET HTTP method for the healthcheck at path `/api/healthcheck` to ensure the service is up. 
I added tests accordingly and also modified the previous tests. 

For the logging added a small recap of information directly at the booting to make sure all the params are correct: 
![cb2e6fbfd8be8bd44bfdc902cda7570f3311b071130a5fc100ae45280ec41660](https://github.com/user-attachments/assets/691ab01c-0a8d-407b-aa6f-9e37de5bef24)


**Tests**

```bash
$go test -v
PASS
ok      github.com/ethereum-optimism/monitorism/op-defender/psp_executor        0.627s
```
