### PR TITLE
feat: Add superchainconfig fetched from env variables. 

### DIFF
--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -43,9 +43,10 @@ func TestHTTPServerHasCorrectRoute(t *testing.T) {
 	metricsfactory := opmetrics.With(opmetrics.NewRegistry())
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 	cfg := CLIConfig{
-		NodeURL:        mockNodeUrl,
-		PortAPI:        "8080",
-		privatekeyflag: GeneratePrivatekey(32),
+		NodeURL:                 mockNodeUrl,
+		PortAPI:                 "8080",
+		privatekeyflag:          GeneratePrivatekey(32),
+		SuperChainConfigAddress: "0x1234567890abcdef1234567890abcdef12345678",
 	}
 	// Initialize the Defender with necessary mock or real components
 	defender, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
@@ -93,9 +94,10 @@ func TestDefenderInitialization(t *testing.T) {
 	metricsfactory := opmetrics.With(opmetrics.NewRegistry())
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 	cfg := CLIConfig{
-		NodeURL:        mockNodeUrl,
-		PortAPI:        "8080",
-		privatekeyflag: GeneratePrivatekey(32),
+		NodeURL:                 mockNodeUrl,
+		PortAPI:                 "8080",
+		privatekeyflag:          GeneratePrivatekey(32),
+		SuperChainConfigAddress: "0x1234567890abcdef1234567890abcdef12345678",
 	}
 	// Initialize the Defender with necessary mock or real components
 	_, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
@@ -115,9 +117,10 @@ func TestHandlePostMockFetch(t *testing.T) {
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 	executor := &SimpleExecutor{}
 	cfg := CLIConfig{
-		NodeURL:        mockNodeUrl,
-		PortAPI:        "8080",
-		privatekeyflag: GeneratePrivatekey(32),
+		NodeURL:                 mockNodeUrl,
+		PortAPI:                 "8080",
+		privatekeyflag:          GeneratePrivatekey(32),
+		SuperChainConfigAddress: "0x1234567890abcdef1234567890abcdef12345678",
 	}
 
 	defender, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)

--- a/op-defender/psp_executor/cli.go
+++ b/op-defender/psp_executor/cli.go
@@ -9,39 +9,45 @@ import (
 )
 
 const (
-	NodeURLFlagName         = "rpc.url"
-	PrivateKeyFlagName      = "privatekey"
-	PortAPIFlagName         = "port.api"
-	ReceiverAddressFlagName = "receiver.address"
-	DataFlagName            = "data"
+	NodeURLFlagName                 = "rpc.url"
+	PrivateKeyFlagName              = "privatekey"
+	PortAPIFlagName                 = "port.api"
+	ReceiverAddressFlagName         = "receiver.address"
+	DataFlagName                    = "data"
+	SuperChainConfigAddressFlagName = "superchainconfig.address"
 )
 
 type CLIConfig struct {
-	NodeURL         string
-	privatekeyflag  string
-	PortAPI         string
-	ReceiverAddress string
-	HexString       string
+	NodeURL                 string
+	privatekeyflag          string
+	PortAPI                 string
+	ReceiverAddress         string
+	HexString               string
+	SuperChainConfigAddress string
 }
 
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 	cfg := CLIConfig{NodeURL: ctx.String(NodeURLFlagName)}
 	if len(PrivateKeyFlagName) == 0 {
-		return cfg, fmt.Errorf("must have a PrivateKeyFlagName set to execute the pause on mainnet")
+		return cfg, fmt.Errorf("must have a PrivateKeyFlagName set to execute the pause.")
 	}
 	cfg.privatekeyflag = ctx.String(PrivateKeyFlagName)
 	if len(PortAPIFlagName) == 0 {
-		return cfg, fmt.Errorf("must have a PortAPIFlagName set to execute the pause on mainnet")
+		return cfg, fmt.Errorf("must have a PortAPIFlagName set to execute the pause.")
 	}
 	cfg.PortAPI = ctx.String(PortAPIFlagName)
 	if len(ReceiverAddressFlagName) == 0 {
-		return cfg, fmt.Errorf("must have a ReceiverAddressFlagName set to receive the pause on mainnet.")
+		return cfg, fmt.Errorf("must have a ReceiverAddressFlagName set to receive the pause.")
 	}
 	cfg.ReceiverAddress = ctx.String(ReceiverAddressFlagName)
 	if len(DataFlagName) == 0 {
-		return cfg, fmt.Errorf("must have a `data` set to execute the calldata on mainnet.")
+		return cfg, fmt.Errorf("must have a `data` set to execute the calldata.")
 	}
 	cfg.HexString = ctx.String(DataFlagName)
+	if len(SuperChainConfigAddressFlagName) == 0 {
+		return cfg, fmt.Errorf("must have a `SuperChainConfigAddress` to know the current status of the superchainconfig.")
+	}
+	cfg.SuperChainConfigAddress = ctx.String(SuperChainConfigAddressFlagName)
 	return cfg, nil
 }
 
@@ -80,6 +86,12 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Usage:    "calldata to execute the pause on mainnet with the signatures.",
 			EnvVars:  opservice.PrefixEnvVar(envPrefix, "CALLDATA"),
 			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     SuperChainConfigAddressFlagName,
+			Usage:    "SuperChainConfig address to know the current status of the superchainconfig.",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "SUPERCHAINCONFIG_ADDRESS"),
+			Required: true,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
In this PR, I have added a new required arg. 
We can use it from environnement with`PSPEXECUTOR_MON_SUPERCHAINCONFIG_ADDRESS` or  from the cli: `--superchainconfig.address`. 

To use it, we can do: 
```shell
export PSPEXECUTOR_MON_SUPERCHAINCONFIG_ADDRESS=0xC2Be75506d5724086DEB7245bd260Cc9753911Be 
```

I have also updated the tests accordingly and make sure the values will be printed at the start of the service.  

**Tests**
I have run the tests and modified to test to ensure this is taking in consideration this arguments.
**Additional context**
