### PR TITLE
Fix test + add testing into the CI for `op-monitorism`. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,10 @@ workflows:
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender
+      - golang-test:
+          name: op-monitorism-golang-test
+          project_name: op-monitorism
+
       - docker-build:
           name: op-monitorism-docker-build
           docker_name: op-monitorism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: run op-defender module tests
+          name: run <<parameters.project_name>> module tests
           command: cd <<parameters.project_name>> && go test ./... -v
 
   docker-build:

--- a/op-monitorism/global_events/types_test.go
+++ b/op-monitorism/global_events/types_test.go
@@ -1,8 +1,10 @@
 package global_events
 
 import (
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/yaml.v3"
+	"io"
 	"testing"
 )
 
@@ -41,7 +43,8 @@ func TestDisplayMonitorAddresses(t *testing.T) {
 	if err != nil {
 		t.Errorf("error: %v", err)
 	}
-	config.DisplayMonitorAddresses()
+	log := oplog.NewLogger(io.Discard, oplog.DefaultCLIConfig())
+	config.DisplayMonitorAddresses(log)
 }
 
 func TestYamlToConfiguration(t *testing.T) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR fix the the previous tests that changed into `op-monitorism` and add a `newlogger`. 
Also this include the CI tests that show that the current tests are passing.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/0f1f8b01-f1a9-4ebc-bb59-b697239ea703">



closes https://github.com/ethereum-optimism/security-pod/issues/142