### PR TITLE
Add `go-linter` to the CI + Fix the previous Linting issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,6 @@ jobs:
       - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
-      - run:
-          command: echo $(ls -lrta)
       - restore_cache:
           name: Restore Go modules cache
           key: gomod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore Go modules cache
-          key: gomod-{{ checksum "<<parameters.project_name>/go.sum" }}
+          key: gomod-{{ checksum "<<parameters.project_name>>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,8 @@ jobs:
       - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
+      - run:
+          command: echo $(pwd)
       - restore_cache:
           name: Restore Go modules cache
           key: gomod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,11 +301,11 @@ workflows:
             - equal: [webhook, << pipeline.trigger_source >>]
     jobs:
       - go-lint:
-        name: op-defender-go-lint
-        project_name: op-defender
+          name: op-defender-go-lint
+          project_name: op-defender
       - go-lint:
-        name: op-monitorism-go-lint
-        project_name: op-monitorism
+          name: op-monitorism-go-lint
+          project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,33 +73,6 @@ jobs:
       - run:
           name: run <<parameters.project_name>> module tests
           command: cd <<parameters.project_name>> && go test ./... -v
-  go-lint:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore Go modules cache
-          key: gomod-{{ checksum "go.sum" }}
-      - restore_cache:
-          key: golang-build-cache
-      - restore_cache:
-          key: golang-lint-cache
-      - run:
-          name: run Go linter
-          command: |
-            # Identify how many cores it defaults to
-            golangci-lint --help | grep concurrency
-            make lint-go
-          working_directory: .
-      - save_cache:
-          key: golang-build-cache
-          paths:
-            - "/root/.cache/go-build"
-      - save_cache:
-          key: golang-lint-cache
-          paths:
-            - "/root/.cache/golangci-lint"
 
   docker-build:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore Go modules cache
-          key: gomod-{{ checksum "<<parameters.project_name>>/go.sum" }}
+          key: gomod-{{ checksum "<< parameters.project_name >>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,9 @@ jobs:
       - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
-      - restore_cache:
-          name: Restore Go modules cache
-          key: gomod-{{ checksum "<< parameters.project_name >>/go.sum" }}
+     # - restore_cache:
+     #     name: Restore Go modules cache
+     #    key: gomod-{{ checksum "<<parameters.project_name>>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,10 +302,10 @@ workflows:
     jobs:
       - go-lint:
           name: op-defender-go-lint
-           project_name: op-defender
+          project_name: op-defender
       - go-lint:
           name: op-monitorism-go-lint
-           project_name: op-monitorism
+          project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,10 +302,10 @@ workflows:
     jobs:
       - go-lint:
           name: op-defender-go-lint
-          project_name: op-defender
+          # project_name: op-defender
       - go-lint:
           name: op-monitorism-go-lint
-          project_name: op-monitorism
+          # project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore Go modules cache
-          key: gomod-{{ checksum "go.sum" }}
+          key: gomod-{{ checksum "<<parameters.project_name>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:
@@ -91,7 +91,7 @@ jobs:
           command: |
             # Identify how many cores it defaults to
             golangci-lint --help | grep concurrency
-            make lint-go
+            make <<parameters.project_name>>-lint-go
           working_directory: .
       - save_cache:
           key: golang-build-cache
@@ -302,10 +302,10 @@ workflows:
     jobs:
       - go-lint:
           name: op-defender-go-lint
-          # project_name: op-defender
+           project_name: op-defender
       - go-lint:
           name: op-monitorism-go-lint
-          # project_name: op-monitorism
+           project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,33 @@ jobs:
       - run:
           name: run <<parameters.project_name>> module tests
           command: cd <<parameters.project_name>> && go test ./... -v
+  go-lint:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          key: golang-build-cache
+      - restore_cache:
+          key: golang-lint-cache
+      - run:
+          name: run Go linter
+          command: |
+            # Identify how many cores it defaults to
+            golangci-lint --help | grep concurrency
+            make lint-go
+          working_directory: .
+      - save_cache:
+          key: golang-build-cache
+          paths:
+            - "/root/.cache/go-build"
+      - save_cache:
+          key: golang-lint-cache
+          paths:
+            - "/root/.cache/golangci-lint"
 
   docker-build:
     environment:
@@ -278,6 +305,33 @@ workflows:
       - golang-test:
           name: op-monitorism-golang-test
           project_name: op-monitorism
+      - go-lint:
+          docker:
+            - image: <<pipeline.parameters.ci_builder_image>>
+          steps:
+            - checkout
+            - restore_cache:
+                name: Restore Go modules cache
+                key: gomod-{{ checksum "go.sum" }}
+            - restore_cache:
+                key: golang-build-cache
+            - restore_cache:
+                key: golang-lint-cache
+            - run:
+                name: run Go linter
+                command: |
+                  # Identify how many cores it defaults to
+                  golangci-lint --help | grep concurrency
+                  make lint-go
+                working_directory: .
+            - save_cache:
+                key: golang-build-cache
+                paths:
+                  - "/root/.cache/go-build"
+            - save_cache:
+                key: golang-lint-cache
+                paths:
+                  - "/root/.cache/golangci-lint"
 
       - docker-build:
           name: op-monitorism-docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,12 @@ workflows:
             # Trigger on new commits
             - equal: [webhook, << pipeline.trigger_source >>]
     jobs:
+      - go-lint:
+        name: op-defender-go-lint
+        project_name: op-defender
+      - go-lint:
+        name: op-monitorism-go-lint
+        project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
   golang-test:
     parameters:
       project_name:
+        description: "name of the project"
         type: string
         default: ""
     shell: /bin/bash -eo pipefail
@@ -77,6 +78,7 @@ jobs:
   go-lint:
     parameters:
       project_name:
+        description: "name of the project"
         type: string
         default: ""
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,17 @@ jobs:
           command: cd <<parameters.project_name>> && go test ./... -v
 
   go-lint:
+    parameters:
+      project_name:
+        type: string
+        default: ""
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
-     # - restore_cache:
-     #     name: Restore Go modules cache
-     #    key: gomod-{{ checksum "<<parameters.project_name>>/go.sum" }}
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "<<parameters.project_name>>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,34 @@ jobs:
           name: run <<parameters.project_name>> module tests
           command: cd <<parameters.project_name>> && go test ./... -v
 
+  go-lint:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          key: golang-build-cache
+      - restore_cache:
+          key: golang-lint-cache
+      - run:
+          name: run Go linter
+          command: |
+            # Identify how many cores it defaults to
+            golangci-lint --help | grep concurrency
+            make lint-go
+          working_directory: .
+      - save_cache:
+          key: golang-build-cache
+          paths:
+            - "/root/.cache/go-build"
+      - save_cache:
+          key: golang-lint-cache
+          paths:
+            - "/root/.cache/golangci-lint"
+
   docker-build:
     environment:
       DOCKER_BUILDKIT: 1
@@ -278,34 +306,6 @@ workflows:
       - golang-test:
           name: op-monitorism-golang-test
           project_name: op-monitorism
-      - go-lint:
-          docker:
-            - image: <<pipeline.parameters.ci_builder_image>>
-          steps:
-            - checkout
-            - restore_cache:
-                name: Restore Go modules cache
-                key: gomod-{{ checksum "go.sum" }}
-            - restore_cache:
-                key: golang-build-cache
-            - restore_cache:
-                key: golang-lint-cache
-            - run:
-                name: run Go linter
-                command: |
-                  # Identify how many cores it defaults to
-                  golangci-lint --help | grep concurrency
-                  make lint-go
-                working_directory: .
-            - save_cache:
-                key: golang-build-cache
-                paths:
-                  - "/root/.cache/go-build"
-            - save_cache:
-                key: golang-lint-cache
-                paths:
-                  - "/root/.cache/golangci-lint"
-
       - docker-build:
           name: op-monitorism-docker-build
           docker_name: op-monitorism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: echo $(pwd)
+          command: echo $(ls -lrta)
       - restore_cache:
           name: Restore Go modules cache
           key: gomod-{{ checksum "go.sum" }}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ op-defender:
 .PHONY: op-defender
 
 lint-go: ## Lints Go code with specific linters
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./op-defender/...
 .PHONY: lint-go
 
 lint-go-fix: ## Lints Go code with specific linters and fixes reported issues

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,21 @@ op-defender:
 	make -C ./op-defender 
 .PHONY: op-defender
 
-lint-go: ## Lints Go code with specific linters
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./op-defender/...
-.PHONY: lint-go
+op-defender-lint-go: ## Lints Go code with specific linters
+	cd op-defender && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: op-defender-lint-go
 
-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
-.PHONY: lint-go-fix
+op-defender-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	cd op-defender && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: op-defender-lint-go-fix
+
+op-monitorism-lint-go: ## Lints Go code with specific linters
+	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: op-onitorism-lint-go
+
+op-monitorism-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: op-monitorism-lint-go-fix
 
 tidy:
 	make -C ./op-monitorism tidy

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ op-defender-lint-go-fix: ## Lints Go code with specific linters and fixes report
 
 op-monitorism-lint-go: ## Lints Go code with specific linters
 	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-.PHONY: op-onitorism-lint-go
+.PHONY: op-monitorism-lint-go
 
 op-monitorism-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
 	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ op-defender:
 	make -C ./op-defender 
 .PHONY: op-defender
 
+lint-go: ## Lints Go code with specific linters
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: lint-go
+
+lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: lint-go-fix
+
 tidy:
 	make -C ./op-monitorism tidy
 	make -C ./op-defender tidy

--- a/op-defender/Makefile
+++ b/op-defender/Makefile
@@ -37,13 +37,6 @@ clean:
 	$(GOCLEAN)
 	rm -f $(BUILD_DIR)/$(BINARY)
 
-lint-go: ## Lints Go code with specific linters
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-.PHONY: lint-go
-
-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
-.PHONY: lint-go-fix
 # Run program
 .PHONY: tidy
 tidy:

--- a/op-defender/Makefile
+++ b/op-defender/Makefile
@@ -37,6 +37,13 @@ clean:
 	$(GOCLEAN)
 	rm -f $(BUILD_DIR)/$(BINARY)
 
+lint-go: ## Lints Go code with specific linters
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: lint-go
+
+lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: lint-go-fix
 # Run program
 .PHONY: tidy
 tidy:

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/hex"
-  "golang.org/x/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -923,7 +923,6 @@ func TestSendTransaction(t *testing.T) {
 	validPrivateKeyGeneratedStr := GeneratePrivatekey(32)
 	validPrivateKeyGenerated, _ := crypto.HexToECDSA(validPrivateKeyGeneratedStr[2:])
 
-	const superChainAddressSepolia = "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 	const rpcURLMainnet = "https://ethereum-rpc.publicnode.com"
 	const rpcURLSepolia = "https://ethereum-sepolia-rpc.publicnode.com"
 	const rpcURLInvalid = "http://www.google.com"

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -6,12 +6,14 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/hex"
-	"golang.org/x/crypto/sha3"
+
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // **********************************************************************

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -68,7 +68,7 @@ type Defender struct {
 	privatekey    *ecdsa.PrivateKey
 	senderAddress common.Address
 	path          string
-	nonce         uint64
+	// nonce         uint64
 	chainID       *big.Int
 	blockDuration time.Duration
 	// superChainConfig
@@ -205,7 +205,7 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 	}
 	if (txHash != common.Hash{}) && (err != nil) { // If the transaction hash is not empty and the error is not nil we return the transaction hash.
 		response := Response{
-			Message: "🚧 Transaction Executed 🚧, but the SuperchainConfig is not *pause*. An error occured: " + err.Error() + ". The TxHash: " + txHash.Hex(),
+			Message: "🚧 Transaction Executed 🚧, but the SuperchainConfig is not *pause*. An error occurred: " + err.Error() + ". The TxHash: " + txHash.Hex(),
 			Status:  http.StatusInternalServerError,
 		}
 
@@ -225,8 +225,6 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to encode response (PSP executed successfully)", http.StatusInternalServerError)
 		return
 	}
-	return
-
 }
 
 // ReturnCorrectChainID is a function that will return the correct chainID based on the chainID provided in the config against the RPC url.
@@ -422,7 +420,7 @@ func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
 
 	client, err := ethclient.Dial(rpc_url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the Ethereum client: %v", err)
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
 	}
 	return client, nil
 }
@@ -540,7 +538,7 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 	simulation, err := SimulateTransaction(ctx, d.l1Client, nil, d.senderAddress, safe_address, calldata)
 	if err != nil {
 		d.log.Warn("🛑 Simulated transaction failed 🛑", "from", d.senderAddress, "to", safe_address, "error", err.Error())
-		return common.Hash{}, fmt.Errorf("failed to simulate transaction: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to simulate transaction: %w", err)
 	}
 
 	d.log.Info("✅ Simulated transaction succeed ✅", "from", d.senderAddress, "to", safe_address, "simulation", hex.EncodeToString(simulation))
@@ -610,7 +608,7 @@ func sendTransaction(client *ethclient.Client, chainID *big.Int, privateKey *ecd
 	// Get the nonce for the current transaction.
 	nonce, err := client.PendingNonceAt(context.Background(), fromAddress)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to get nonce: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to get nonce: %w", err)
 	}
 	value := amount                            // Amount of ether to send in wei
 	gasLimit := uint64(1000 * DefaultGasLimit) // In units TODO: Need to use `estimateGas()` to get the correct value.

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -614,7 +614,7 @@ func sendTransaction(client *ethclient.Client, chainID *big.Int, privateKey *ecd
 	gasLimit := uint64(1000 * DefaultGasLimit) // In units TODO: Need to use `estimateGas()` to get the correct value.
 	gasPrice, err := client.SuggestGasPrice(context.Background())
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to suggest gas price: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to suggest gas price: %w", err)
 	}
 
 	tx := types.NewTransaction(nonce, toAddress, value, gasLimit, gasPrice, data) //@TODO: Need to use `NewTx` instead of `NewTransaction` as it is deprecated in future version of `op-defender`.
@@ -622,13 +622,13 @@ func sendTransaction(client *ethclient.Client, chainID *big.Int, privateKey *ecd
 	// Sign the transaction with the private key
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to sign transaction: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
 	// Send the transaction
 	err = client.SendTransaction(context.Background(), signedTx)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to send transaction: %v", err)
+		return common.Hash{}, fmt.Errorf("failed to send transaction: %w", err)
 	}
 
 	return signedTx.Hash(), nil

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -2,11 +2,12 @@ package psp_executor
 
 import (
 	"context"
+	"math/big"
+	"strconv"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"math/big"
-	"strconv"
 )
 
 // SimulateTransaction will simulate a transaction onchain if the blockNumber is `nil` it will simulate the transaction on the latest block.

--- a/op-monitorism/fault/monitor.go
+++ b/op-monitorism/fault/monitor.go
@@ -184,7 +184,7 @@ func (m *Monitor) Run(ctx context.Context) {
 
 	// Continue
 
-	m.log.Info("validated ouput", "index", m.currOutputIndex, "output_root", outputRoot.String(), "finalization_time", time.Unix(int64(block.Time()+m.faultProofWindow), 0).String())
+	m.log.Info("validated output", "index", m.currOutputIndex, "output_root", outputRoot.String(), "finalization_time", time.Unix(int64(block.Time()+m.faultProofWindow), 0).String())
 	m.highestOutputIndex.WithLabelValues("checked").Set(float64(m.currOutputIndex))
 
 	m.currOutputIndex++

--- a/op-monitorism/global_events/monitor.go
+++ b/op-monitorism/global_events/monitor.go
@@ -3,7 +3,10 @@ package global_events
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,9 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"regexp"
-	"strings"
-	"time"
 )
 
 const (
@@ -29,13 +29,13 @@ type Monitor struct {
 	l1Client     *ethclient.Client
 	globalconfig GlobalConfiguration
 	// nickname is the nickname of the monitor (we need to change the name this is not an ideal one here).
-	nickname    string
-	safeAddress *bindings.OptimismPortalCaller
+	nickname string
+	//safeAddress *bindings.OptimismPortalCaller
 
 	LiveAddress *common.Address
 
-	filename   string //filename of the yaml rules
-	yamlconfig Configuration
+	//filename   string //filename of the yaml rules
+	//yamlconfig Configuration
 
 	// Prometheus metrics
 	eventEmitted        *prometheus.CounterVec
@@ -83,7 +83,7 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 
 	globalConfig.DisplayMonitorAddresses(log) //Display all the addresses that are monitored.
 	log.Info("--------------------------------------- End of Infos -----------------------------\n")
-	time.Sleep(10 * time.Second) // sleep for 10 seconds usefull to read the information before the prod.
+	time.Sleep(10 * time.Second) // sleep for 10 seconds useful to read the information before the prod.
 	return &Monitor{
 		log:          log,
 		l1Client:     l1Client,

--- a/op-monitorism/global_events/monitor_test.go
+++ b/op-monitorism/global_events/monitor_test.go
@@ -1,8 +1,9 @@
 package global_events
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestFormatSignature(t *testing.T) {

--- a/op-monitorism/global_events/types.go
+++ b/op-monitorism/global_events/types.go
@@ -3,11 +3,12 @@ package global_events
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path/filepath"
 )
 
 // EventTopic is the struct that will contain the index of the topic and the values that will be monitored (not used currently).
@@ -37,7 +38,7 @@ type GlobalConfiguration struct {
 	Configuration []Configuration `yaml:"configuration"`
 }
 
-// ReturnEventsMonitoredForAnAddress will return the list of events monitored for a given address /!\ This will return the first occurence of the address in the configuration.
+// ReturnEventsMonitoredForAnAddress will return the list of events monitored for a given address /!\ This will return the first occurrence of the address in the configuration.
 // We assume currently there is no duplicates into the rules.
 func (G GlobalConfiguration) ReturnEventsMonitoredForAnAddress(target_address common.Address) []Event {
 	for _, config := range G.Configuration {
@@ -51,7 +52,7 @@ func (G GlobalConfiguration) ReturnEventsMonitoredForAnAddress(target_address co
 
 }
 
-// ReturnEventsMonitoredForAnAddressFromAConfig will return the list of events monitored for a given address from a given configuration. /!\ This will return the first occurence of the address in the configuration. As we assume currently there is no duplicates into the rules.
+// ReturnEventsMonitoredForAnAddressFromAConfig will return the list of events monitored for a given address from a given configuration. /!\ This will return the first occurrence of the address in the configuration. As we assume currently there is no duplicates into the rules.
 func (G GlobalConfiguration) ReturnEventsMonitoredForAnAddressFromAConfig(target_address common.Address, config Configuration) []Event {
 	for _, address := range config.Addresses {
 		if address == target_address {
@@ -151,6 +152,10 @@ func ReadAllYamlRules(PathYamlRules string, log log.Logger) (GlobalConfiguration
 	}
 
 	yaml_marshalled, err := yaml.Marshal(GlobalConfig)
+	if err != nil {
+		log.Warn("Fail to marshal GlobalConfig to yaml", "ERROR", err)
+		panic("Fail to marshal GlobalConfig to yaml")
+	}
 	err = os.WriteFile("/tmp/globalconfig.yaml", yaml_marshalled, 0644) // Storing the configuration if we need to debug and knows what is monitored in the future.
 	if err != nil {
 		log.Warn("Error writing the globalconfig YAML file on the disk:", "ERROR", err)

--- a/op-monitorism/global_events/types.go
+++ b/op-monitorism/global_events/types.go
@@ -105,7 +105,7 @@ func StringFunctionToHex(config Configuration, log log.Logger) Configuration {
 		return FinalConfig
 	}
 	// If there is addresses to monitor, we will resolve the signature of the events.
-	for _ = range config.Addresses { //resolve the hex signature from a topic
+	for range config.Addresses { //resolve the hex signature from a topic
 		keccak256_topic_0 := config.Events
 		for i, event := range config.Events {
 			keccak256_topic_0[i].Keccak256_Signature = FormatAndHash(event.Signature)

--- a/op-monitorism/global_events/types_test.go
+++ b/op-monitorism/global_events/types_test.go
@@ -1,11 +1,12 @@
 package global_events
 
 import (
+	"io"
+	"testing"
+
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/yaml.v3"
-	"io"
-	"testing"
 )
 
 const data = `

--- a/op-monitorism/liveness_expiration/monitor.go
+++ b/op-monitorism/liveness_expiration/monitor.go
@@ -191,24 +191,24 @@ func (m *Monitor) Run(ctx context.Context) {
 		deadline_date := time.Unix(int64(deadline), 0)
 		formattedDate := deadline_date.Format("Monday, January 2, 2006")
 		// 4. Ensure that the invariant is not broken -> (block.timestamp + BUFFER > lastLive(owner) + livenessInterval) == true
-		result, borrow := bits.Sub64(deadline, now, 0)
+		remainingTime, borrow := bits.Sub64(deadline, now, 0)
 		if borrow != 0 {
 			m.log.Warn("`deadline - now` is negative means that the `owner` is not active anymore at all and should be removed fast! This is not suppose to happen because we will be intervening before ensure that is not happening", "deadline", deadline, "now", now, "owner", owner)
 		}
 
-		days_left_before_deadline := result / day
+		days_left_before_deadline := remainingTime / day
 
 		m.log.Info("", "owner", owner, "now", now, "deadline", deadline, "lastlive", lastLive, "interval", interval, "deadline_date", formattedDate, "days_left_before_deadline", days_left_before_deadline)
 		m.ownerDaysBeforeDeadline.WithLabelValues(owner.String()).Set(float64(days_left_before_deadline))
 
-		if result <= 1*day {
+		if remainingTime <= 1*day {
 			m.log.Info("deadline is less than 1 day we need to ensure that the owner is doing something in the last 24h otherwise we need to remove it!", "lastLive", lastLive, "owner", owner)
 			m.ownerStalePeriod.WithLabelValues(owner.String()).Set(float64(1))
-		} else if result <= 7*day {
+		} else if remainingTime <= 7*day {
 			m.log.Info("deadline is less than 7 days we need to ensure that the owner is doing something in the last 7 days otherwise we need to remove it!", "lastLive", lastLive, "owner", owner)
 			m.ownerStalePeriod.WithLabelValues(owner.String()).Set(float64(7))
 
-		} else if result <= 14*day {
+		} else if remainingTime <= 14*day {
 			m.log.Info("deadline is less than 14 days we need to ensure that the owner is doing something in the last 14 days otherwise we need to remove it!", "lastLive", lastLive, "owner", owner)
 			m.ownerStalePeriod.WithLabelValues(owner.String()).Set(float64(14))
 

--- a/op-monitorism/multisig/monitor.go
+++ b/op-monitorism/multisig/monitor.go
@@ -47,7 +47,7 @@ type Monitor struct {
 	optimismPortal        *bindings.OptimismPortalCaller
 	nickname              string
 
-	onePassToken string
+	//onePassToken string
 	onePassVault *string
 	safeAddress  *common.Address
 

--- a/op-monitorism/secrets/monitor.go
+++ b/op-monitorism/secrets/monitor.go
@@ -209,7 +209,7 @@ func (m *Monitor) Run(ctx context.Context) {
 			return
 		}
 
-		// Check if the initation secret exists.
+		// Check if the initiation secret exists.
 		secretHex1 := common.Bytes2Hex(checkparams.SecretHashMustExist[:])
 		m.log.Info("checking initiation secret", "name", name, "hash", secretHex1)
 		exists1, err := dripcheck.RevealedSecrets(&callOpts, checkparams.SecretHashMustExist)
@@ -221,7 +221,7 @@ func (m *Monitor) Run(ctx context.Context) {
 
 		// Update metrics.
 		if exists1.Cmp(big.NewInt(0)) > 0 {
-			m.log.Info("revealed initation secret", "name", name, "hash", secretHex1)
+			m.log.Info("revealed initiation secret", "name", name, "hash", secretHex1)
 			m.revealedSecrets.WithLabelValues("initiation", name, secretHex1).Set(1)
 		}
 

--- a/op-monitorism/withdrawals/monitor.go
+++ b/op-monitorism/withdrawals/monitor.go
@@ -92,7 +92,7 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 		withdrawalsValidated: m.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Name:      "withdrawalsValidated",
-			Help:      "number of withdrawals succesfully validated",
+			Help:      "number of withdrawals successfully validated",
 		}),
 		highestBlockNumber: m.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR is adding the `go-linter` into the CI. 
This will allow us to improve the code clarity each time we are pushing. 
Before pushing the new linting we decided to clean the linting issues to avoid having the CI failing thanks @nodauf for his contribution here.

**Tests**
All tests have been down locally + into the current CI. 


**Metadata**

Fixes https://github.com/ethereum-optimism/monitorism/issues/69
