### PR TITLE
Allow RPC Sepolia Production RPC

### DIFF
--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -226,7 +226,8 @@ func TestCheckAndReturnRPC(t *testing.T) {
 		expectError bool
 	}{
 		{"Empty URL", "", true},
-		{"Production URL", "https://mainnet.infura.io", true},
+		{"Production URL Mainnet", "https://mainnet.infura.io", true},
+		{"Production URL Sepolia", "https://sepolia.infura.io", false},
 		{"Valid Tenderly Fork URL", "https://rpc.tenderly.co/fork/some-id", false},
 	}
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -314,8 +314,8 @@ func CheckAndReturnRPC(rpc_url string) (*ethclient.Client, error) {
 	if rpc_url == "" {
 		return nil, fmt.Errorf("rpc.url is not set.")
 	}
-	if !strings.Contains(rpc_url, "rpc.tenderly.co/fork") { // Check if the RPC is a production one. if yes return an error, as we should not execute the pause on the production chain in the first version.
-		return nil, fmt.Errorf("rpc.url doesn't contains \"fork\" is a production RPC.")
+	if !strings.Contains(rpc_url, "rpc.tenderly.co/fork") && !strings.Contains(rpc_url, "sepolia") { // Check if the RPC is a mainnet production. if yes return an error, as we should not execute the pause on the fork or sepolia chain in the first version.
+		return nil, fmt.Errorf("rpc.url doesn't contains \"fork\" or \"sepolia\" so this is a production RPC on mainnet")
 	}
 
 	client, err := ethclient.Dial(rpc_url)


### PR DESCRIPTION


**Description**

This PR introduce an allowance of the RPC that contains "Sepolia" to be executed without forking environnement.

**Tests**

I have made update the  test `TestCheckAndReturnRPC()`. 
```go
{"Production URL Mainnet", "https://mainnet.infura.io", true},
{"Production URL Sepolia", "https://sepolia.infura.io", false},
```
