### PR TITLE
Improve the HTTP server response + type usage `common.hash` instead of `String`. 

### DIFF
--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -22,9 +22,9 @@ import (
 
 type SimpleExecutor struct{}
 
-func (e *SimpleExecutor) FetchAndExecute(d *Defender) error {
+func (e *SimpleExecutor) FetchAndExecute(d *Defender) (common.Hash, error) {
 	// Do nothing for now, for mocking purposes
-	return nil
+	return common.Hash{}, nil
 }
 
 func (e *SimpleExecutor) ReturnCorrectChainID(l1client *ethclient.Client, chainID uint64) (*big.Int, error) { // Do nothing for now, for mocking purposes

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -182,7 +182,7 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	if (txHash != common.Hash{}) && (err != nil) { // If the transaction hash is not empty and the error is not nil we return the transaction hash.
 		response := Response{
-			Message: "🚧 Transaction Executed 🚧, but the contract is not *pause*. An error occured: " + err.Error() + ". The TxHash: " + txHash.Hex(),
+			Message: "🚧 Transaction Executed 🚧, but the SuperchainConfig is not *pause*. An error occured: " + err.Error() + ". The TxHash: " + txHash.Hex(),
 			Status:  http.StatusInternalServerError,
 		}
 		json.NewEncoder(w).Encode(response)

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -188,7 +188,7 @@ func (d *Defender) handlePost(w http.ResponseWriter, r *http.Request) {
 			Status:  http.StatusInternalServerError,
 		}
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			http.Error(w, "failed to encode response (Error)", http.StatusInternalServerError)
+			http.Error(w, "failed to encode response (`TxHash` is set to `nil`)", http.StatusInternalServerError)
 			return
 		}
 		return

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -456,7 +457,9 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 		return common.Hash{}, err
 	}
 	if pause_before_transaction {
-		log.Crit("The SuperChainConfig is already paused! Exiting the program.")
+
+		return common.Hash{}, errors.New("the SuperChainConfig is already paused")
+
 	}
 	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
 	log.Info("Current parameters", "SuperchainConfigAddress", d.superChainConfigAddress, "safe_address", d.safeAddress, "chainID", d.chainID)

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -92,9 +92,8 @@ type PSP struct {
 	Data         []byte
 	DataStr      string `json:"data"`
 	Signatures   []struct {
-		Signer common.Address `json:"signer"`
-		// `Signature` has to have the `0x` prefix
-		Signature []byte `json:"signature"`
+		Signer    common.Address `json:"signer"`
+		Signature string         `json:"signature"`
 	} `json:"signatures"`
 	Calldata    []byte
 	CalldataStr string `json:"calldata"`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR Improve the HTTP server response + type usage `common.hash` instead of `String`.  This now return the `TxHash` to help the triagger to quickly make sure the transaction is valid on chain. 
 
![b17dbabef0aeedc2ff6c4d1b4efdda793c78b6ca0071609094fa9052603fb8cb](https://github.com/user-attachments/assets/3fc8a720-0762-40bb-9a5c-acda83620687)
This also introduce an error if the super-chain is not pause after the transaction has been executed without any error.
And also return an error if the superchain is paused before doing the pause. 
![5d9d34a44d669815dbf6aef9e7f52d09dbe88ead5eb7b691d4d8aef91e79ea8c](https://github.com/user-attachments/assets/2863d5dd-178e-411d-aacd-6b4abe9238b5)


**Tests**
Fix the tests with the new signatures. 
**Additional context**

This is part of the https://github.com/ethereum-optimism/security-pod/issues/148


