### PR TITLE
WIP: Feat(Simulation) to `SimulateTransaction()` the PSPs before executing them onchain

### DIFF
--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -105,6 +105,7 @@ latestSafeNonce     *prometheus.GaugeVec
 pspNonceValid       *prometheus.GaugeVec
 highestBlockNumber  *prometheus.GaugeVec
 unexpectedRpcErrors *prometheus.CounterVec
+GetNonceAndFetchAndSimulateAtBlockError *prometheus.CounterVec
 ```
 
 ### 4. Options and Configuration

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -36,7 +36,7 @@ Explanation of the options:
 | `--superchainconfig.address` | 0xC2Be75506d5724086DEB7245bd260Cc9753911Be | Address of SuperchainConfig contract |
 | `--rpc.url` | http://localhost:8545 | URL of the RPC node |
 | `--port.api` | 8080 | Port for the HTTP API server |
-
+| `--blockduration` | 12 | Time between 2 blocks on the current network |
 **PSPs Format**
 The PSPs are stored with a JSON format. The JSON file should contain an array of PSPs. Each PSP should have the following fields:
 
@@ -95,6 +95,16 @@ The metrics are using **Prometheus** and can be set with the following options:
 | `--metrics.enabled` | Enable the metrics server | `false` | `DEFENDER_METRICS_ENABLED` |
 | `--metrics.addr` | Metrics listening address | `"0.0.0.0"` | `$DEFENDER_METRICS_ADDR` |
 | `--metrics.port` | Metrics listening port | `7300` | `$DEFENDER_METRICS_PORT` |
+
+The prometheus metrics used are the following:
+
+```golang
+latestValidPspNonce *prometheus.GaugeVec
+latestSafeNonce     *prometheus.GaugeVec
+pspNonceValid       *prometheus.GaugeVec
+highestBlockNumber  *prometheus.GaugeVec
+unexpectedRpcErrors *prometheus.CounterVec
+```
 
 ### 4. Options and Configuration
 

--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -36,7 +36,8 @@ Explanation of the options:
 | `--superchainconfig.address` | 0xC2Be75506d5724086DEB7245bd260Cc9753911Be | Address of SuperchainConfig contract |
 | `--rpc.url` | http://localhost:8545 | URL of the RPC node |
 | `--port.api` | 8080 | Port for the HTTP API server |
-| `--blockduration` | 12 | Time between 2 blocks on the current network |
+
+| `--port.api` | 8080 | Port for the HTTP API server |
 **PSPs Format**
 The PSPs are stored with a JSON format. The JSON file should contain an array of PSPs. Each PSP should have the following fields:
 
@@ -110,15 +111,18 @@ unexpectedRpcErrors *prometheus.CounterVec
 
 The current options are the following:
 
-```
+Using the `--help` flag will show the options available:
+
 OPTIONS:
+
+```shell
    --rpc.url value                   Node URL of a peer (default: "http://127.0.0.1:8545") [$PSPEXECUTOR_NODE_URL]
    --privatekey value                Privatekey of the account that will issue the pause transaction [$PSPEXECUTOR_PRIVATE_KEY]
    --port.api value                  Port of the API server you want to listen on (e.g. 8080) (default: 8080) [$PSPEXECUTOR_PORT_API]
-   --data value                      calldata to execute the pause on mainnet with the signatures [$PSPEXECUTOR_CALLDATA]
    --superchainconfig.address value  SuperChainConfig address to know the current status of the superchainconfig [$PSPEXECUTOR_SUPERCHAINCONFIG_ADDRESS]
    --safe.address value              Safe address that will execute the PSPs [$PSPEXECUTOR_SAFE_ADDRESS]
    --path value                      Absolute path to the JSON file containing the PSPs [$PSPEXECUTOR_PATH_TO_PSPS]
+   --blockduration value             Block duration of the current chain that op-defender is running on (default: 12) [$PSPEXECUTOR_BLOCK_DURATION]
    --chainid value                   ChainID of the current chain that op-defender is running on (default: 0) [$PSPEXECUTOR_CHAIN_ID]
    --log.level value                 The lowest log level that will be output (default: INFO) [$DEFENDER_LOG_LEVEL]
    --log.format value                Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$DEFENDER_LOG_FORMAT]

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -910,10 +910,6 @@ func TestSendTransaction(t *testing.T) {
 	const rpcURLMainnet = "https://ethereum-rpc.publicnode.com"
 	const rpcURLSepolia = "https://ethereum-sepolia-rpc.publicnode.com"
 	const rpcURLInvalid = "http://www.google.com"
-	//l1ClientMainnet, err := ethclient.Dial(rpcURLMainnet)
-	//if err != nil {
-	//	t.Errorf("Fail to connet to RPC %s: %v", rpcURLMainnet, err)
-	//}
 
 	l1ClientSepolia, err := ethclient.Dial(rpcURLSepolia)
 	if err != nil {

--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -640,6 +640,7 @@ func TestGetNonceSafe(t *testing.T) {
 	const safeAddressSepolia = "0x837DE453AD5F21E89771e3c06239d8236c0EFd5E"
 	const rpcURLMainnet = "https://ethereum-rpc.publicnode.com"
 	const rpcURLSepolia = "https://ethereum-sepolia-rpc.publicnode.com"
+
 	l1ClientMainnet, err := ethclient.Dial(rpcURLMainnet)
 	if err != nil {
 		t.Errorf("Fail to connet to RPC %s: %v", rpcURLMainnet, err)
@@ -655,8 +656,13 @@ func TestGetNonceSafe(t *testing.T) {
 
 	// Initialize the Defender with necessary mock or real components
 	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
-	metricsRegistry := opmetrics.NewRegistry()
-	metricsfactory := opmetrics.With(metricsRegistry)
+
+	metricsRegistry_mainnet := opmetrics.NewRegistry()
+	metricsRegistry_sepolia := opmetrics.NewRegistry()
+	metricsRegistry_sepolia_error := opmetrics.NewRegistry()
+	metricsfactory_mainnet := opmetrics.With(metricsRegistry_mainnet)
+	metricsfactory_sepolia := opmetrics.With(metricsRegistry_sepolia)
+	metricsfactory_sepolia_error := opmetrics.With(metricsRegistry_sepolia_error)
 	executor := &SimpleExecutor{}
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 
@@ -670,21 +676,21 @@ func TestGetNonceSafe(t *testing.T) {
 		BlockDuration:           12,
 	}
 
-	defenderMainnet, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderMainnet, err := NewDefender(context.Background(), logger, metricsfactory_mainnet, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
 	defenderMainnet.l1Client = l1ClientMainnet
 	defenderMainnet.operationSafe = safeAddressMainnetBindings
 
-	defenderSepolia, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderSepolia, err := NewDefender(context.Background(), logger, metricsfactory_sepolia, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
 	defenderSepolia.l1Client = l1ClientSepolia
 	defenderSepolia.operationSafe = safeAddressSepoliaBindings
 
-	defenderError, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderError, err := NewDefender(context.Background(), logger, metricsfactory_sepolia_error, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
@@ -836,8 +842,12 @@ func TestCheckPauseStatus(t *testing.T) {
 
 	// Initialize the Defender with necessary mock or real components
 	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
-	metricsRegistry := opmetrics.NewRegistry()
-	metricsfactory := opmetrics.With(metricsRegistry)
+	metricsRegistry_mainnet := opmetrics.NewRegistry()
+	metricsRegistry_sepolia := opmetrics.NewRegistry()
+	metricsRegistry_sepolia_error := opmetrics.NewRegistry()
+	metricsfactory_mainnet := opmetrics.With(metricsRegistry_mainnet)
+	metricsfactory_sepolia := opmetrics.With(metricsRegistry_sepolia)
+	metricsfactory_sepolia_error := opmetrics.With(metricsRegistry_sepolia_error)
 	executor := &SimpleExecutor{}
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
 
@@ -851,21 +861,21 @@ func TestCheckPauseStatus(t *testing.T) {
 		BlockDuration:           12,
 	}
 
-	defenderMainnet, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderMainnet, err := NewDefender(context.Background(), logger, metricsfactory_mainnet, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
 	defenderMainnet.l1Client = l1ClientMainnet
 	defenderMainnet.superChainConfig = superChainAddressMainnetBindings
 
-	defenderSepolia, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderSepolia, err := NewDefender(context.Background(), logger, metricsfactory_sepolia, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}
 	defenderSepolia.l1Client = l1ClientSepolia
 	defenderSepolia.superChainConfig = superChainAddressSepoliaBindings
 
-	defenderError, err := NewDefender(context.Background(), logger, metricsfactory, cfg, executor)
+	defenderError, err := NewDefender(context.Background(), logger, metricsfactory_sepolia_error, cfg, executor)
 	if err != nil {
 		t.Fatalf("Failed to create Defender: %v", err)
 	}

--- a/op-defender/psp_executor/cli.go
+++ b/op-defender/psp_executor/cli.go
@@ -15,16 +15,18 @@ const (
 	SafeAddressFlagName             = "safe.address"
 	PathFlagName                    = "path"
 	ChainIDFlagName                 = "chainid"
+	BlockDurationFlagName           = "blockduration"
 )
 
 type CLIConfig struct {
 	NodeURL                 string
 	PortAPI                 string
 	Path                    string
+	BlockDuration           uint64
 	privatekeyflag          string
 	SuperChainConfigAddress common.Address
 	SafeAddress             common.Address
-	chainID                 uint64
+	ChainID                 uint64
 }
 
 func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
@@ -35,7 +37,8 @@ func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
 		privatekeyflag:          ctx.String(PrivateKeyFlagName),
 		SuperChainConfigAddress: common.HexToAddress(ctx.String(SuperChainConfigAddressFlagName)),
 		SafeAddress:             common.HexToAddress(ctx.String(SafeAddressFlagName)),
-		chainID:                 ctx.Uint64(ChainIDFlagName),
+		ChainID:                 ctx.Uint64(ChainIDFlagName),
+		BlockDuration:           ctx.Uint64(BlockDurationFlagName),
 	}
 
 	return cfg, nil
@@ -79,6 +82,13 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Usage:    "Absolute path to the JSON file containing the PSPs",
 			EnvVars:  opservice.PrefixEnvVar(envPrefix, "PATH_TO_PSPS"),
 			Required: true,
+		},
+		&cli.Uint64Flag{
+			Name:     BlockDurationFlagName,
+			Usage:    "Block duration of the current chain that op-defender is running on",
+			Value:    12,
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "BLOCK_DURATION"),
+			Required: false,
 		},
 		&cli.Uint64Flag{
 			Name:     ChainIDFlagName,

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -534,13 +534,13 @@ func (d *Defender) Run(ctx context.Context) {
 				continue
 			}
 
-			res, err := d.executor.FetchAndSimulateAtBlock(d, blocknumber, nonce)
+			_, err = d.executor.FetchAndSimulateAtBlock(d, blocknumber, nonce)
 			if err != nil {
-				d.log.Error("[MON] failed to fetch and simulate the PSP onchain", "error", err, "blocknumber", blocknumber)
+				d.log.Error("[MON] failed to fetch and simulate the PSP onchain", "error", err, "blocknumber", blocknumber, "nonce", nonce)
 				// log prometheus metric FetchAndSimulateAtBlock
 				continue
 			}
-			d.log.Info("[MON] PSP executed onchain successfully ✅", "blocknumber", blocknumber, "simulation", hex.EncodeToString(res))
+			d.log.Info("[MON] PSP executed onchain successfully ✅", "blocknumber", blocknumber, "nonce", nonce)
 		}
 	}()
 

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -519,10 +519,10 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 		log.Error("failed to check the pause status of the SuperChainConfig", "error", err, "superchainconfig_address", d.superChainConfigAddress)
 		return common.Hash{}, err
 	}
-
 	if pause_before_transaction {
 		return common.Hash{}, errors.New("the SuperChainConfig is already paused")
 	}
+
 	d.log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
 	d.log.Info("Current parameters", "SuperchainConfigAddress", d.superChainConfigAddress, "safe_address", d.safeAddress, "chainID", d.chainID)
 
@@ -543,13 +543,14 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 
 	// 4. Check the status of the SuperChainConfig after the transaction is set to pause.
 	pause_after_transaction, err := d.checkPauseStatus(ctx)
-	if !pause_after_transaction {
-		return txHash, fmt.Errorf("failed to pause the SuperChainConfig")
-	}
 	if err != nil {
 		d.log.Error("failed to check the pause status of the SuperChainConfig", "error", err, "superchainconfig_address", d.superChainConfigAddress)
 		return common.Hash{}, err
 	}
+	if !pause_after_transaction {
+		return txHash, fmt.Errorf("failed to pause the SuperChainConfig")
+	}
+
 	d.log.Info("[After Transaction] status of the pause()", "pause", pause_after_transaction)
 
 	return txHash, nil

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -476,11 +476,12 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 		log.Error("failed to check the pause status of the SuperChainConfig", "error", err, "superchainconfig_address", d.superChainConfigAddress)
 		return common.Hash{}, err
 	}
-	if pause_before_transaction {
-
-		return common.Hash{}, errors.New("the SuperChainConfig is already paused")
-
-	}
+	errors.New("the SuperChainConfig is already paused")
+	// if pause_before_transaction {
+	//
+	// 	return common.Hash{}, errors.New("the SuperChainConfig is already paused")
+	//
+	// }
 	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
 	log.Info("Current parameters", "SuperchainConfigAddress", d.superChainConfigAddress, "safe_address", d.safeAddress, "chainID", d.chainID)
 
@@ -542,8 +543,11 @@ func sendTransaction(client *ethclient.Client, chainID *big.Int, privateKey *ecd
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to get nonce: %v", err)
 	}
-
 	// Set up the transaction parameters
+	_, err = SimulateTransaction(client, fromAddress, toAddress, data)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to simulate transaction: %v", err)
+	}
 	value := amount                            // Amount of ether to send in wei
 	gasLimit := uint64(1000 * DefaultGasLimit) // In units TODO: Need to use `estimateGas()` to get the correct value.
 	gasPrice, err := client.SuggestGasPrice(context.Background())

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -488,7 +488,7 @@ func (d *Defender) ExecutePSPOnchain(ctx context.Context, safe_address common.Ad
 	log.Info("[Before Transaction] status of the pause()", "pause", pause_before_transaction)
 	log.Info("Current parameters", "SuperchainConfigAddress", d.superChainConfigAddress, "safe_address", d.safeAddress, "chainID", d.chainID)
 
-	// Simulate the transaction to check if it will succeed before sending it onchain.
+	// Simulate the transaction to check if it will succeed before sending it onchain if blocknumber = nil this simulate at the last block
 	simulation, err := SimulateTransaction(ctx, d.l1Client, nil, d.senderAddress, safe_address, calldata)
 	if err != nil {
 		d.log.Warn("🛑 Simulated transaction failed 🛑", "from", d.senderAddress, "to", safe_address, "error", err.Error())

--- a/op-defender/psp_executor/defender.go
+++ b/op-defender/psp_executor/defender.go
@@ -529,7 +529,6 @@ func (d *Defender) Run(ctx context.Context) {
 				// log prometheus metric unexpectedRpcErrors
 				continue
 			}
-			ctx := context.Background()
 			nonce, err := d.getNonceSafe(ctx) // Get the the current nonce of the operationSafe.
 			if err != nil {
 				continue

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -2,7 +2,6 @@ package psp_executor
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -23,11 +22,10 @@ func SimulateTransaction(client *ethclient.Client, fromAddress common.Address, c
 	ctx := context.Background()
 
 	// Simulate the transaction
-	result, err := client.CallContract(ctx, callMsg, nil)
+	_, err := client.CallContract(ctx, callMsg, nil)
 	if err != nil {
+
 		return nil, err
 	}
-
-	fmt.Printf("Simulation result: %x\n", result)
 	return &callMsg, nil
 }

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -2,11 +2,11 @@ package psp_executor
 
 import (
 	"context"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"math/big"
+	"strconv"
 )
 
 // SimulateTransaction will simulate a transaction onchain if the blockNumber is `nil` it will simulate the transaction on the latest block.
@@ -49,4 +49,34 @@ func (e *DefenderExecutor) FetchAndSimulateAtBlock(ctx context.Context, d *Defen
 		return nil, err
 	}
 	return simulation, nil
+}
+
+// GetNonceAndFetchAndSimulateAtBlock will get the nonce of the operationSafe onchain and then fetch the PSP from a file and simulate it onchain at the last block.
+func (d *Defender) GetNonceAndFetchAndSimulateAtBlock(ctx context.Context) error {
+	blocknumber, err := d.l1Client.BlockNumber(ctx) // Get the latest block number.
+	if err != nil {
+		d.log.Error("[MON] failed to get the block number:", "error", err)
+		d.unexpectedRpcErrors.WithLabelValues("l1", "blockNumber").Inc()
+		return err
+	}
+	d.highestBlockNumber.WithLabelValues("blockNumber").Set(float64(blocknumber))
+	nonce, err := d.getNonceSafe(ctx) // Get the the current nonce of the operationSafe.
+	if err != nil {
+		// log prometheus metric FetchAndSimulateAtBlock
+		d.unexpectedRpcErrors.WithLabelValues("l1", "latestSafeNonce").Inc()
+		d.log.Error("[MON] failed to get latest nonce onchain ", "error", err, "blocknumber", blocknumber)
+		return err
+	}
+	d.latestSafeNonce.WithLabelValues("nonce").Set(float64(nonce))
+
+	_, err = d.executor.FetchAndSimulateAtBlock(ctx, d, &blocknumber, nonce) // Fetch and simulate the PSP with the current nonce.
+	if err != nil {
+		d.log.Error("[MON] failed to fetch and simulate the PSP onchain", "error", err, "blocknumber", blocknumber, "nonce", nonce)
+		d.pspNonceValid.WithLabelValues(strconv.FormatUint(nonce, 10)).Set(0)
+		return err
+	}
+	d.pspNonceValid.WithLabelValues(strconv.FormatUint(nonce, 10)).Set(1)
+	d.latestValidPspNonce.WithLabelValues("nonce").Set(float64(nonce))
+	d.log.Info("[MON] PSP executed onchain successfully ✅", "blocknumber", blocknumber, "nonce", nonce)
+	return nil
 }

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -1,0 +1,33 @@
+package psp_executor
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+func SimulateTransaction(client *ethclient.Client, fromAddress common.Address, contractAddress common.Address, data []byte) (*ethereum.CallMsg, error) {
+	// Create a call message
+	callMsg := ethereum.CallMsg{
+		From:  fromAddress,
+		To:    &contractAddress,
+		Data:  data,
+		Value: &big.Int{},
+	}
+
+	// Context with a background
+	ctx := context.Background()
+
+	// Simulate the transaction
+	result, err := client.CallContract(ctx, callMsg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Simulation result: %x\n", result)
+	return &callMsg, nil
+}

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -62,7 +62,6 @@ func (d *Defender) GetNonceAndFetchAndSimulateAtBlock(ctx context.Context) error
 	d.highestBlockNumber.WithLabelValues("blockNumber").Set(float64(blocknumber))
 	nonce, err := d.getNonceSafe(ctx) // Get the the current nonce of the operationSafe.
 	if err != nil {
-		// log prometheus metric FetchAndSimulateAtBlock
 		d.unexpectedRpcErrors.WithLabelValues("l1", "latestSafeNonce").Inc()
 		d.log.Error("[MON] failed to get latest nonce onchain ", "error", err, "blocknumber", blocknumber)
 		return err

--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func SimulateTransaction(client *ethclient.Client, fromAddress common.Address, contractAddress common.Address, data []byte) (*ethereum.CallMsg, error) {
+func SimulateTransaction(client *ethclient.Client, fromAddress common.Address, contractAddress common.Address, data []byte) ([]byte, error) {
 	// Create a call message
 	callMsg := ethereum.CallMsg{
 		From:  fromAddress,
@@ -22,10 +22,27 @@ func SimulateTransaction(client *ethclient.Client, fromAddress common.Address, c
 	ctx := context.Background()
 
 	// Simulate the transaction
-	_, err := client.CallContract(ctx, callMsg, nil)
+	simulation, err := client.CallContract(ctx, callMsg, nil) //@TODO: Add the block number better for debugging
 	if err != nil {
 
 		return nil, err
 	}
-	return &callMsg, nil
+	return simulation, nil
+}
+
+// FetchAndSimulate will fetch the PSP from a file and simulate it this onchain.
+func (e *DefenderExecutor) FetchAndSimulateAtBlock(d *Defender, blocknumber uint64, nonce uint64) ([]byte, error) {
+	operationSafe, data, err := GetPSPbyNonceFromFile(nonce, d.path) // return the PSP that has the correct nonce.
+	if err != nil {
+		return nil, err
+	}
+	if operationSafe != d.safeAddress {
+		return nil, err
+	}
+	// When the PSP is fetched correctly then simulate it onchain with the PSP data through the `SimulateTransaction()` function.
+	simulation, err := SimulateTransaction(d.l1Client, d.senderAddress, operationSafe, data)
+	if err != nil {
+		return nil, err
+	}
+	return simulation, nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR introduce a simulator for testing the validity of the PSPs and send the metrics of the simulation through prometheus. 

If the simulation of the transaction is not valid. Then, we will not execute the Onchain transaction like below:  
![507c1dc96bf758922399e89425b7ed119fb6648fde450d736a213d4896085578](https://github.com/user-attachments/assets/7ed8f5ca-bf6f-4250-9771-d30ff4e9c0f3)

When the simulation succeed this will continue the workflow and pause the superchain config: 
![ae87e50466a8b83a68fa21b856f70a552aa7b1cff8b27218510e1c6b58f89182](https://github.com/user-attachments/assets/8f9982a2-b06e-42e1-9941-79c8077bd89f)

On the following small video we can see differents cases that the PSPs might be valid, or invalid, or not present with the correct nonces. 
We can see that the PSPs are simulated every 2 seconds approx and if there is incorrect data then this will return a value and metrics into prometheus.

https://github.com/user-attachments/assets/65c57c74-add2-4575-85a9-b4b2da80d826




**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**
During the writing of this PR realized that the `newTransaction()` is using legacy transaction.  
```go
tx := types.NewTransaction(nonce, toAddress, value, gasLimit, gasPrice, data) //@TODO: Need to use `NewTx` instead of `NewTransaction` as it is deprecated in future version of `op-defender`.
```
This is not an issue for us with the current codebase but would be better to upgrade for sake of consistency. 
In future PR (I have introduce a comment to mention it into the codebase). 
**Metadata**

This is part of: https://github.com/ethereum-optimism/security-pod/issues/147