### PR TITLE
Fix go-lint in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore Go modules cache
-          key: gomod-{{ checksum "go.sum" }}
+          key: gomod-{{ checksum "<<parameters.project_name>/go.sum" }}
       - restore_cache:
           key: golang-build-cache
       - restore_cache:
@@ -91,7 +91,7 @@ jobs:
           command: |
             # Identify how many cores it defaults to
             golangci-lint --help | grep concurrency
-            make lint-go
+            make <<parameters.project_name>>-lint-go
           working_directory: .
       - save_cache:
           key: golang-build-cache
@@ -302,10 +302,10 @@ workflows:
     jobs:
       - go-lint:
           name: op-defender-go-lint
-          # project_name: op-defender
+           project_name: op-defender
       - go-lint:
           name: op-monitorism-go-lint
-          # project_name: op-monitorism
+           project_name: op-monitorism
       - golang-test:
           name: op-defender-golang-test
           project_name: op-defender

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,21 @@ op-defender:
 	make -C ./op-defender 
 .PHONY: op-defender
 
-lint-go: ## Lints Go code with specific linters
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./op-defender/...
-.PHONY: lint-go
+op-defender-lint-go: ## Lints Go code with specific linters
+	cd op-defender && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: op-defender-lint-go
 
-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
-.PHONY: lint-go-fix
+op-defender-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	cd op-defender && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: op-defender-lint-go-fix
+
+op-monitorism-lint-go: ## Lints Go code with specific linters
+	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: op-onitorism-lint-go
+
+op-monitorism-lint-go-fix: ## Lints Go code with specific linters and fixes reported issues
+	cd op-monitorism && golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./... --fix
+.PHONY: op-monitorism-lint-go-fix
 
 tidy:
 	make -C ./op-monitorism tidy


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

As discussed privately with @Ethnical, this is a contribution to the PR #62 for the issue #69. `golangci-lint` does not support monorepos, so it was necessary to change the directory to the appropriate project before running the linter. The `Makefile` has been updated to reflect this change.

Then the `circleci` file was updated to use the appropriate target in the `Makefile`, utilizing the `project_name` variable.

An attempt was made to fix the `restore_cache` action, but as I wasn't able to fully test it, there may still be issues.

**Additional context**

The new target in `Makefile` returns the following output:

_op-monitorism-lint-go_
![image](https://github.com/user-attachments/assets/3d521ae8-9d05-4448-b5f2-cdf975b62935)

_op-defender-lint-go_
![image](https://github.com/user-attachments/assets/23271203-ebf6-4500-96a7-3536e3e699ec)


**Metadata**

- Fixes #69 
