### PR TITLE
chore(metrics): Refactor and add a metrics for the tracking the balance of the sender of the PSPs. 

### DIFF
--- a/op-defender/psp_executor/simulator.go
+++ b/op-defender/psp_executor/simulator.go
@@ -52,6 +52,17 @@ func (e *DefenderExecutor) FetchAndSimulateAtBlock(ctx context.Context, d *Defen
 	return simulation, nil
 }
 
+// GetBalance will get the balance of the senderAddress
+func (d *Defender) GetBalance(ctx context.Context) error {
+	balance, err := d.l1Client.BalanceAt(ctx, d.senderAddress, nil)
+	if err != nil {
+		return err
+	}
+	balanceInEther := weiToEther(balance)
+	d.balanceSenderAddress.WithLabelValues(d.senderAddress.Hex()).Set(balanceInEther)
+	return nil
+}
+
 // GetNonceAndFetchAndSimulateAtBlock will get the nonce of the operationSafe onchain and then fetch the PSP from a file and simulate it onchain at the last block.
 func (d *Defender) GetNonceAndFetchAndSimulateAtBlock(ctx context.Context) error {
 	blocknumber, err := d.l1Client.BlockNumber(ctx) // Get the latest block number.

--- a/op-defender/psp_executor/utils.go
+++ b/op-defender/psp_executor/utils.go
@@ -1,0 +1,14 @@
+package psp_executor
+
+import (
+	"math/big"
+)
+
+// weiToEther converts a wei value to ether return a float64.
+func weiToEther(wei *big.Int) float64 {
+	num := new(big.Rat).SetInt(wei)
+	denom := big.NewRat(1e18, 1)
+	num = num.Quo(num, denom)
+	f, _ := num.Float64()
+	return f
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR include a refactor + the add of the feature `GetBalance()`. 
and a new metric prometheus `balanceSenderAddress`: 
![b4ca91fd623bb14d09c7da83b737ec99a22d9d51eb4e2b1a5cfbeccfb6b792e0](https://github.com/user-attachments/assets/fb361c8f-7aef-4780-8b47-ddfff1741f88)


**Tests**
I have tested locally with differentes balances. 

**Additional context**


**Metadata**

This is part of https://github.com/ethereum-optimism/security-pod/issues/147
