### PR TITLE
chore: return zero if the value is 0 for `weiToEther`

### DIFF
--- a/op-defender/psp_executor/utils.go
+++ b/op-defender/psp_executor/utils.go
@@ -9,6 +9,10 @@ const ether = 1e18
 
 // weiToEther converts a wei value to ether return a float64 return an error if the float is too large.
 func weiToEther(wei *big.Int) (float64, error) {
+	var bigInt big.Int
+	if wei.Cmp(&bigInt) == 0 {
+		return 0, nil
+	}
 	num := new(big.Rat).SetInt(wei)
 	denom := big.NewRat(ether, 1)
 	num = num.Quo(num, denom)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR improve the return of the function `weiToEther()` when the input is zero this will return 0. 

