### PR TITLE
Add `ARM64` architecture Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ workflows:
           docker_name: op-monitorism
           docker_tags: <<pipeline.git.revision>>
           requires: ["hold"]
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           publish: true
           release: true
           context:
@@ -297,7 +297,7 @@ workflows:
           docker_name: op-defender
           docker_tags: <<pipeline.git.revision>>
           requires: ["hold"]
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           publish: true
           release: true
           context:
@@ -326,7 +326,7 @@ workflows:
           name: op-monitorism-docker-build
           docker_name: op-monitorism
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          platforms: "linux/amd64,linux/arm64"
+          platforms: "linux/amd64"
           publish: true
           context:
             - oplabs-gcr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
           name: op-monitorism-docker-build
           docker_name: op-monitorism
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           publish: true
           context:
             - oplabs-gcr


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Building for arm64 on release of the images.

**Tests**

Add support for arm64 on release of docker.
![Screenshot 2024-10-02 at 10 01 36](https://github.com/user-attachments/assets/e12b13e0-961d-437f-9021-ae7dfd7fd5a3)


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**
This will fix the issue 170: https://github.com/ethereum-optimism/security-pod/issues/170
