### PR TITLE
Feat: Add mtls authentication for the API

### DIFF
--- a/op-defender/cmd/defender/cli.go
+++ b/op-defender/cmd/defender/cli.go
@@ -56,6 +56,9 @@ func PSPExecutorMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse psp_executor config from flags: %w", err)
 	}
+	if err := cfg.Check(); err != nil {
+		return nil, err
+	}
 
 	metricsRegistry := opmetrics.NewRegistry()
 	executor := &executor.DefenderExecutor{}


### PR DESCRIPTION
**Description**

This PR add mTLS authentication for the API (#77). The `op-service` from the monorepo already implements the necessary requirements for this. I made a few adjustments since the default values are set for the TLS flags ([default values](https://github.com/ethereum-optimism/optimism/blob/c2dc0abfd3cc98cdb19587a0d079a889dd69f19e/op-service/tls/cli.go#L45)). As a result, the checks ([checks](https://github.com/ethereum-optimism/optimism/blob/c2dc0abfd3cc98cdb19587a0d079a889dd69f19e/op-service/tls/cli.go#L77)) always indicated that TLS was enabled, even when the user didn't provide the arguments.

Regarding your infrastructure, I'm not sure if using middleware might be a better option than what I implemented. The middleware could allow some endpoints (like the healthcheck) to bypass the mTLS. What are you though on this?

**Tests**

The feature was tested using the following command line:
```bash
go run main.go cli.go psp_executor --privatekey 0x2592897534a1873b0fdc91c6ac0ba938eeb19cd502b650072fe71fbc0105db92 --superchainconfig.address 0x0F24Af6B7147aAEf00b216Cd38667256DC56755a --safe.address 0x0F24Af6B7147aAEf00b216Cd38667256DC56755a --path /tmp/whatever --chainid 11155
111 --tls.ca certs/ca-cert.pem --tls.cert certs/server-cert.pem --tls.key certs/server-key.pem --rpc.url https://ethereum-sepolia.rpc.subquery.network/public --port.api 8443
```

And then it was confirmed that only client that are authenticated using a certificate can access the API:

``` bash
> curl https://localhost:8443/api/healthcheck -k  --cert client-cert.pem --key client-key.pem
OK
> curl https://localhost:8443/api/healthcheck -k
curl: (56) OpenSSL SSL_read: OpenSSL/3.3.1: error:0A00045C:SSL routines::tlsv13 alert certificate required, errno 0
```
The files used in the previous command can be found below:
[certs.zip](https://github.com/user-attachments/files/17232449/certs.zip)



**Metadata**

- Fixes #77 
