### PR TITLE
Improving metrics

### DIFF
--- a/op-monitorism/faultproof_withdrawals/monitor.go
+++ b/op-monitorism/faultproof_withdrawals/monitor.go
@@ -282,6 +282,10 @@ func (m *Monitor) Run(ctx context.Context) {
 // It returns any events detected during the consumption that requires to be re-analysed again at a later stage (when the event referenced DisputeGame completes).
 func (m *Monitor) ConsumeEvents(enrichedWithdrawalEvents map[common.Hash]*validator.EnrichedProvenWithdrawalEvent) error {
 	for _, enrichedWithdrawalEvent := range enrichedWithdrawalEvents {
+		if enrichedWithdrawalEvent == nil {
+			m.log.Error("WITHDRAWAL: enrichedWithdrawalEvent is nil in ConsumeEvents")
+			panic("WITHDRAWAL: enrichedWithdrawalEvent is nil in ConsumeEvents")
+		}
 		m.log.Info("processing withdrawal event", "event", enrichedWithdrawalEvent)
 		err := m.withdrawalValidator.UpdateEnrichedWithdrawalEvent(enrichedWithdrawalEvent)
 		//upgrade state to the latest L2 height	after the event is processed

--- a/op-monitorism/faultproof_withdrawals/monitor.go
+++ b/op-monitorism/faultproof_withdrawals/monitor.go
@@ -280,10 +280,10 @@ func (m *Monitor) Run(ctx context.Context) {
 
 // ConsumeEvents processes a slice of enriched withdrawal events and updates their states.
 // It returns any events detected during the consumption that requires to be re-analysed again at a later stage (when the event referenced DisputeGame completes).
-func (m *Monitor) ConsumeEvents(enrichedWithdrawalEvents map[common.Hash]validator.EnrichedProvenWithdrawalEvent) error {
+func (m *Monitor) ConsumeEvents(enrichedWithdrawalEvents map[common.Hash]*validator.EnrichedProvenWithdrawalEvent) error {
 	for _, enrichedWithdrawalEvent := range enrichedWithdrawalEvents {
-		m.log.Info("processing withdrawal event", "event", &enrichedWithdrawalEvent)
-		err := m.withdrawalValidator.UpdateEnrichedWithdrawalEvent(&enrichedWithdrawalEvent)
+		m.log.Info("processing withdrawal event", "event", enrichedWithdrawalEvent)
+		err := m.withdrawalValidator.UpdateEnrichedWithdrawalEvent(enrichedWithdrawalEvent)
 		//upgrade state to the latest L2 height	after the event is processed
 		m.state.latestL2Height = m.withdrawalValidator.GetLatestL2Height()
 		if err != nil {
@@ -303,11 +303,11 @@ func (m *Monitor) ConsumeEvents(enrichedWithdrawalEvents map[common.Hash]validat
 
 // ConsumeEvent processes a single enriched withdrawal event.
 // It logs the event details and checks for any forgery detection.
-func (m *Monitor) ConsumeEvent(enrichedWithdrawalEvent validator.EnrichedProvenWithdrawalEvent) error {
+func (m *Monitor) ConsumeEvent(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) error {
 	if enrichedWithdrawalEvent.DisputeGame.DisputeGameData.L2ChainID.Cmp(m.l2ChainID) != 0 {
 		m.log.Error("l2ChainID mismatch", "expected", fmt.Sprintf("%d", m.l2ChainID), "got", fmt.Sprintf("%d", enrichedWithdrawalEvent.DisputeGame.DisputeGameData.L2ChainID))
 	}
-	valid, err := m.withdrawalValidator.IsWithdrawalEventValid(&enrichedWithdrawalEvent)
+	valid, err := m.withdrawalValidator.IsWithdrawalEventValid(enrichedWithdrawalEvent)
 	if err != nil {
 		m.log.Error("failed to check if forgery detected", "error", err)
 		return err

--- a/op-monitorism/faultproof_withdrawals/monitor_live_sepolia_test.go
+++ b/op-monitorism/faultproof_withdrawals/monitor_live_sepolia_test.go
@@ -128,8 +128,8 @@ func TestConsumeEventValid_DEFENDER_WINS_Sepolia(t *testing.T) {
 		},
 	}
 
-	eventsMap := map[common.Hash]validator.EnrichedProvenWithdrawalEvent{
-		validEvent.Event.WithdrawalHash: validEvent,
+	eventsMap := map[common.Hash]*validator.EnrichedProvenWithdrawalEvent{
+		validEvent.Event.WithdrawalHash: &validEvent,
 	}
 	err := test_monitor.ConsumeEvents(eventsMap)
 	require.NoError(t, err)
@@ -179,8 +179,8 @@ func TestConsumeEventValid_CHALLENGER_WINS_Sepolia(t *testing.T) {
 		},
 	}
 
-	eventsMap := map[common.Hash]validator.EnrichedProvenWithdrawalEvent{
-		event.Event.WithdrawalHash: event,
+	eventsMap := map[common.Hash]*validator.EnrichedProvenWithdrawalEvent{
+		event.Event.WithdrawalHash: &event,
 	}
 	err := test_monitor.ConsumeEvents(eventsMap)
 	require.NoError(t, err)
@@ -230,8 +230,8 @@ func TestConsumeEventValid_BlacklistedSepolia(t *testing.T) {
 		},
 	}
 
-	eventsMap := map[common.Hash]validator.EnrichedProvenWithdrawalEvent{
-		event.Event.WithdrawalHash: event,
+	eventsMap := map[common.Hash]*validator.EnrichedProvenWithdrawalEvent{
+		event.Event.WithdrawalHash: &event,
 	}
 	err := test_monitor.ConsumeEvents(eventsMap)
 	require.NoError(t, err)
@@ -280,8 +280,8 @@ func TestConsumeEventForgery1Sepolia(t *testing.T) {
 		},
 	}
 
-	eventsMap := map[common.Hash]validator.EnrichedProvenWithdrawalEvent{
-		validEvent.Event.WithdrawalHash: validEvent,
+	eventsMap := map[common.Hash]*validator.EnrichedProvenWithdrawalEvent{
+		validEvent.Event.WithdrawalHash: &validEvent,
 	}
 	err := test_monitor.ConsumeEvents(eventsMap)
 	require.NoError(t, err)
@@ -330,8 +330,8 @@ func TestConsumeEventForgery2Sepolia(t *testing.T) {
 		},
 	}
 
-	eventsMap := map[common.Hash]validator.EnrichedProvenWithdrawalEvent{
-		event.Event.WithdrawalHash: event,
+	eventsMap := map[common.Hash]*validator.EnrichedProvenWithdrawalEvent{
+		event.Event.WithdrawalHash: &event,
 	}
 	err := test_monitor.ConsumeEvents(eventsMap)
 	require.NoError(t, err)

--- a/op-monitorism/faultproof_withdrawals/state.go
+++ b/op-monitorism/faultproof_withdrawals/state.go
@@ -108,7 +108,7 @@ func (s *State) LogState() {
 }
 
 func (s *State) IncrementWithdrawalsValidated(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
-	s.logger.Info("STATE WITHDRAWAL: valid", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+	s.logger.Info("STATE WITHDRAWAL: valid", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 	s.withdrawalsProcessed++
 	enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
 }
@@ -116,12 +116,12 @@ func (s *State) IncrementWithdrawalsValidated(enrichedWithdrawalEvent *validator
 func (s *State) IncrementPotentialAttackOnDefenderWinsGames(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 
-	s.logger.Error("STATE WITHDRAWAL: is NOT valid, forgery detected", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+	s.logger.Error("STATE WITHDRAWAL: is NOT valid, forgery detected", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 	s.potentialAttackOnDefenderWinsGames[key] = enrichedWithdrawalEvent
 	s.numberOfPotentialAttacksOnDefenderWinsGames++
 
 	if _, ok := s.potentialAttackOnInProgressGames[key]; ok {
-		s.logger.Error("STATE WITHDRAWAL: added to potential attacks. Removing from inProgress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+		s.logger.Error("STATE WITHDRAWAL: added to potential attacks. Removing from inProgress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 		delete(s.potentialAttackOnInProgressGames, key)
 		s.numberOfPotentialAttackOnInProgressGames--
 	}
@@ -135,9 +135,9 @@ func (s *State) IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEven
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 	// check if key already exists
 	if _, ok := s.potentialAttackOnInProgressGames[key]; ok {
-		s.logger.Error("STATE WITHDRAWAL:is NOT valid, game is still in progress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+		s.logger.Error("STATE WITHDRAWAL:is NOT valid, game is still in progress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 	} else {
-		s.logger.Error("STATE WITHDRAWAL:is NOT valid, game is still in progress. New game found In Progress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+		s.logger.Error("STATE WITHDRAWAL:is NOT valid, game is still in progress. New game found In Progress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 		s.numberOfPotentialAttackOnInProgressGames++
 		enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
 
@@ -150,12 +150,12 @@ func (s *State) IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEven
 func (s *State) IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 
-	s.logger.Error("STATE WITHDRAWAL:is NOT valid, but the game is correctly resolved", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+	s.logger.Error("STATE WITHDRAWAL:is NOT valid, but the game is correctly resolved", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 	s.suspiciousEventsOnChallengerWinsGames.Add(key, enrichedWithdrawalEvent)
 	s.numberOfSuspiciousEventsOnChallengerWinsGames++
 
 	if _, ok := s.potentialAttackOnInProgressGames[key]; ok {
-		s.logger.Error("STATE WITHDRAWAL: added to suspicious attacks. Removing from inProgress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
+		s.logger.Error("STATE WITHDRAWAL: added to suspicious attacks. Removing from inProgress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
 		delete(s.potentialAttackOnInProgressGames, key)
 		s.numberOfPotentialAttackOnInProgressGames--
 	}
@@ -404,7 +404,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 			fmt.Sprintf("%v", event.Enriched),
 			fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 			event.Event.Raw.TxHash.String(),
-		).Set(event.ProcessedTimeStamp) // Set a value  for existence
+		).Set(event.ProcessedTimeStamp) // Set the timestamp of when the event was processed
 	}
 
 	// Clear the previous values
@@ -425,7 +425,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 			fmt.Sprintf("%v", event.Enriched),
 			fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 			event.Event.Raw.TxHash.String(),
-		).Set(event.ProcessedTimeStamp) // Set a value  for existence
+		).Set(event.ProcessedTimeStamp) // Set the timestamp of when the event was processed
 	}
 
 	// Clear the previous values
@@ -448,8 +448,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 				fmt.Sprintf("%v", event.Enriched),
 				fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 				event.Event.Raw.TxHash.String(),
-			).Set(event.ProcessedTimeStamp) // Set a value  for existence
+			).Set(event.ProcessedTimeStamp) // Set the timestamp of when the event was processed
 		}
 	}
-
 }

--- a/op-monitorism/faultproof_withdrawals/state.go
+++ b/op-monitorism/faultproof_withdrawals/state.go
@@ -3,6 +3,7 @@ package faultproof_withdrawals
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/ethereum-optimism/monitorism/op-monitorism/faultproof_withdrawals/validator"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -32,12 +33,12 @@ type State struct {
 	// possible attacks detected
 
 	// Forgeries detected on games that are already resolved
-	potentialAttackOnDefenderWinsGames          map[common.Hash]validator.EnrichedProvenWithdrawalEvent
+	potentialAttackOnDefenderWinsGames          map[common.Hash]*validator.EnrichedProvenWithdrawalEvent
 	numberOfPotentialAttacksOnDefenderWinsGames uint64
 
 	// Forgeries detected on games that are still in progress
 	// Faultproof system should make them invalid
-	potentialAttackOnInProgressGames         map[common.Hash]validator.EnrichedProvenWithdrawalEvent
+	potentialAttackOnInProgressGames         map[common.Hash]*validator.EnrichedProvenWithdrawalEvent
 	numberOfPotentialAttackOnInProgressGames uint64
 
 	// Suspicious events
@@ -54,7 +55,7 @@ func NewState(logger log.Logger, nextL1Height uint64, latestL1Height uint64, lat
 	}
 
 	ret := State{
-		potentialAttackOnDefenderWinsGames:          make(map[common.Hash]validator.EnrichedProvenWithdrawalEvent),
+		potentialAttackOnDefenderWinsGames:          make(map[common.Hash]*validator.EnrichedProvenWithdrawalEvent),
 		numberOfPotentialAttacksOnDefenderWinsGames: 0,
 		suspiciousEventsOnChallengerWinsGames: func() *lru.Cache {
 			cache, err := lru.New(suspiciousEventsOnChallengerWinsGamesCacheSize)
@@ -66,7 +67,7 @@ func NewState(logger log.Logger, nextL1Height uint64, latestL1Height uint64, lat
 		}(),
 		numberOfSuspiciousEventsOnChallengerWinsGames: 0,
 
-		potentialAttackOnInProgressGames:         make(map[common.Hash]validator.EnrichedProvenWithdrawalEvent),
+		potentialAttackOnInProgressGames:         make(map[common.Hash]*validator.EnrichedProvenWithdrawalEvent),
 		numberOfPotentialAttackOnInProgressGames: 0,
 
 		eventsProcessed: 0,
@@ -106,12 +107,13 @@ func (s *State) LogState() {
 	)
 }
 
-func (s *State) IncrementWithdrawalsValidated(enrichedWithdrawalEvent validator.EnrichedProvenWithdrawalEvent) {
+func (s *State) IncrementWithdrawalsValidated(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	s.logger.Info("STATE WITHDRAWAL: valid", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
 	s.withdrawalsProcessed++
+	enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
 }
 
-func (s *State) IncrementPotentialAttackOnDefenderWinsGames(enrichedWithdrawalEvent validator.EnrichedProvenWithdrawalEvent) {
+func (s *State) IncrementPotentialAttackOnDefenderWinsGames(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 
 	s.logger.Error("STATE WITHDRAWAL: is NOT valid, forgery detected", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
@@ -125,9 +127,11 @@ func (s *State) IncrementPotentialAttackOnDefenderWinsGames(enrichedWithdrawalEv
 	}
 
 	s.withdrawalsProcessed++
+	enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
+
 }
 
-func (s *State) IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEvent validator.EnrichedProvenWithdrawalEvent) {
+func (s *State) IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 	// check if key already exists
 	if _, ok := s.potentialAttackOnInProgressGames[key]; ok {
@@ -135,13 +139,15 @@ func (s *State) IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEven
 	} else {
 		s.logger.Error("STATE WITHDRAWAL:is NOT valid, game is still in progress. New game found In Progress", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
 		s.numberOfPotentialAttackOnInProgressGames++
+		enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
+
 	}
 
 	// eventually update the map with the new enrichedWithdrawalEvent
 	s.potentialAttackOnInProgressGames[key] = enrichedWithdrawalEvent
 }
 
-func (s *State) IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawalEvent validator.EnrichedProvenWithdrawalEvent) {
+func (s *State) IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) {
 	key := enrichedWithdrawalEvent.Event.Raw.TxHash
 
 	s.logger.Error("STATE WITHDRAWAL:is NOT valid, but the game is correctly resolved", "TxHash", fmt.Sprintf("%v", enrichedWithdrawalEvent.Event.Raw.TxHash), "enrichedWithdrawalEvent", &enrichedWithdrawalEvent)
@@ -155,7 +161,7 @@ func (s *State) IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawa
 	}
 
 	s.withdrawalsProcessed++
-
+	enrichedWithdrawalEvent.ProcessedTimeStamp = float64(time.Now().Unix())
 }
 
 func (s *State) GetPercentages() (uint64, uint64) {
@@ -380,6 +386,9 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 	}
 	m.previousNodeConnectionFailures = state.nodeConnectionFailures
 
+	// Clear the previous values
+	m.PotentialAttackOnDefenderWinsGamesGaugeVec.Reset()
+
 	// Update metrics for forgeries withdrawals events
 	for _, event := range state.potentialAttackOnDefenderWinsGames {
 		withdrawalHash := common.BytesToHash(event.Event.WithdrawalHash[:]).Hex()
@@ -395,7 +404,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 			fmt.Sprintf("%v", event.Enriched),
 			fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 			event.Event.Raw.TxHash.String(),
-		).Set(1) // Set a value  for existence
+		).Set(event.ProcessedTimeStamp) // Set a value  for existence
 	}
 
 	// Clear the previous values
@@ -416,7 +425,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 			fmt.Sprintf("%v", event.Enriched),
 			fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 			event.Event.Raw.TxHash.String(),
-		).Set(1) // Set a value  for existence
+		).Set(event.ProcessedTimeStamp) // Set a value  for existence
 	}
 
 	// Clear the previous values
@@ -425,8 +434,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 	for _, key := range state.suspiciousEventsOnChallengerWinsGames.Keys() {
 		enrichedEvent, ok := state.suspiciousEventsOnChallengerWinsGames.Get(key)
 		if ok {
-			event := enrichedEvent.(validator.EnrichedProvenWithdrawalEvent)
-
+			event := enrichedEvent.(*validator.EnrichedProvenWithdrawalEvent)
 			withdrawalHash := common.BytesToHash(event.Event.WithdrawalHash[:]).Hex()
 			proofSubmitter := event.Event.ProofSubmitter.String()
 			status := event.DisputeGame.DisputeGameData.Status.String()
@@ -440,7 +448,7 @@ func (m *Metrics) UpdateMetricsFromState(state *State) {
 				fmt.Sprintf("%v", event.Enriched),
 				fmt.Sprintf("%v", event.Event.Raw.BlockNumber),
 				event.Event.Raw.TxHash.String(),
-			).Set(1) // Set a value  for existence
+			).Set(event.ProcessedTimeStamp) // Set a value  for existence
 		}
 	}
 

--- a/op-monitorism/faultproof_withdrawals/validator/proven_withdrawal_validator.go
+++ b/op-monitorism/faultproof_withdrawals/validator/proven_withdrawal_validator.go
@@ -29,6 +29,7 @@ type EnrichedProvenWithdrawalEvent struct {
 	Blacklisted               bool                             // Indicates if the game is blacklisted.
 	WithdrawalHashPresentOnL2 bool                             // Indicates if the withdrawal hash is present on L2.
 	Enriched                  bool                             // Indicates if the event is enriched.
+	ProcessedTimeStamp        float64                          // Unix TimeStamp seconds when the event was processed.
 }
 
 // ProvenWithdrawalValidator validates proven withdrawal events.
@@ -205,13 +206,13 @@ func (wv *ProvenWithdrawalValidator) GetEnrichedWithdrawalsEvents(start uint64, 
 
 // GetEnrichedWithdrawalsEvents retrieves enriched withdrawal events within the specified block range.
 // It returns a slice of EnrichedProvenWithdrawalEvent along with any error encountered.
-func (wv *ProvenWithdrawalValidator) GetEnrichedWithdrawalsEventsMap(start uint64, end *uint64) (map[common.Hash]EnrichedProvenWithdrawalEvent, error) {
+func (wv *ProvenWithdrawalValidator) GetEnrichedWithdrawalsEventsMap(start uint64, end *uint64) (map[common.Hash]*EnrichedProvenWithdrawalEvent, error) {
 	iterator, err := wv.optimismPortal2Helper.GetProvenWithdrawalsExtension1EventsIterator(start, end)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get proven withdrawals extension1 iterator error:%w", err)
 	}
 
-	enrichedProvenWithdrawalEvents := make(map[common.Hash]EnrichedProvenWithdrawalEvent)
+	enrichedProvenWithdrawalEvents := make(map[common.Hash]*EnrichedProvenWithdrawalEvent)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -229,7 +230,7 @@ func (wv *ProvenWithdrawalValidator) GetEnrichedWithdrawalsEventsMap(start uint6
 		}
 
 		key := enrichedWithdrawalEvent.Event.Raw.TxHash
-		enrichedProvenWithdrawalEvents[key] = *enrichedWithdrawalEvent
+		enrichedProvenWithdrawalEvents[key] = enrichedWithdrawalEvent
 	}
 
 	return enrichedProvenWithdrawalEvents, nil


### PR DESCRIPTION
 
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
Passing events via reference instead of keeping copying them.
Adding the precessed time in the event to keep track of when they have being processed

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field `ProcessedTimeStamp` in the enriched withdrawal event structure for better event tracking.

- **Improvements**
	- Enhanced event handling efficiency by switching from value types to pointer types for enriched withdrawal events throughout the application.
	- Updated internal logic for logging and event processing to utilize pointers, improving performance and memory efficiency.

- **Bug Fixes**
	- Refined error handling and event processing logic to ensure consistent behavior with the updated parameter types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->