### PR TITLE
docs: fix typo Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Reviewers should submit their review with either `Approve` or `Request changes` 
 
 If the reviewer selects `Request changes`, they should clearly indicate which changes they require in order to approve.
 
-If the reviewer selects `Approves`, they should either:
+If the reviewer selects `Approve`, they should either:
 1. immediately merge it, or
 2. indicate what further review they deem necessary (and from whom).
 


### PR DESCRIPTION
**Description**

There is a small typo in the text:

1. **"Approves"** should be **"Approve"** in the phrase:
   - *"If the reviewer selects `Approves`, they should either:"*

The correct version should be:
- *"If the reviewer selects `Approve`, they should either:"*

Thanks for OP!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `CONTRIBUTING.md` file to clarify the contribution process.
	- Emphasized the importance of opening issues for non-trivial changes.
	- Refined guidelines for PR authors, including commit message format and testing requirements.
	- Added suggestions for enhancing clarity in code reviews and PR templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->