### PR TITLE
docs: Fix incorrect anchor Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     - [Multisig Monitor](#multisig-monitor)
     - [Drippie Monitor](#drippie-monitor)
     - [Secrets Monitor](#secrets-monitor)
-    - [Faultproof Withdrawals](#secrets-monitor)
+    - [Faultproof Withdrawals](#faultproof-withdrawal)
   - [Defender Components](#defender-components)
     - [HTTP API PSP Executor Service](#http-api-psp-executor-service)
   - [CLI &amp; Docs](#cli--docs)


### PR DESCRIPTION
**Description**

This update corrects a minor but misleading error in the Table of Contents under the "Monitors Components" section. The link for **Faultproof Withdrawals** mistakenly pointed to the same anchor as **Secrets Monitor** (`#secrets-monitor`).  

The updated link now correctly points to the relevant section:
```markdown
- [Faultproof Withdrawals](#faultproof-withdrawal)
```

This ensures that readers navigating the document land on the intended section, improving clarity and usability. Thank you for maintaining such a detailed and well-organized documentation!

**Thanks for OP!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the section header from "Faultproof Withdrawals" to "Faultproof Withdrawal" in the README.md file.
	- Adjusted the table of contents to reflect the header change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->