### PR TITLE
docs: typo fixes Update README.md

### DIFF
--- a/op-defender/README.md
+++ b/op-defender/README.md
@@ -2,7 +2,7 @@
 
 _op-defender_ is an active security service allowing to provide automated defense for the OP Stack.
 
-The following the commands are currently available:
+The following commands are currently available:
 
 ```bash
 NAME:
@@ -27,7 +27,7 @@ GLOBAL OPTIONS:
    --version, -v  print the version
 ```
 
-Each _defenders_ has some common configuration, that are configurable both via CLI or environment variables with defaults values.
+Each _defender_ has some common configuration, that are configurable both via CLI or environment variables with default values.
 
 ### PSP Executor Service
 


### PR DESCRIPTION
**Description**

1. **Fixed redundant wording in the commands section:**  
   - Replaced:  
     ```markdown
     The following the commands are currently available:
     ```  
   - With:  
     ```markdown
     The following commands are currently available:
     ```  

2. **Corrected singular/plural mismatch in "Each _defenders_":**  
   - Replaced:  
     ```markdown
     Each _defenders_ has some common configuration
     ```  
   - With:  
     ```markdown
     Each _defender_ has some common configuration
     ```  

3. **Aligned phrasing of "Defaults values" to proper form:**  
   - Replaced:  
     ```markdown
     defaults values
     ```  
   - With:  
     ```markdown
     default values
     ```  

**Thanks for OP!**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved grammatical accuracy and clarity in the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->