### PR TITLE
docs: Fix grammatical error Update README.md

### DIFF
--- a/op-monitorism/withdrawals/README.md
+++ b/op-monitorism/withdrawals/README.md
@@ -1,5 +1,5 @@
 # Purpose of the Service
-Withdrawal has the following purpose:
+`Withdrawals` has the following purpose:
 - Monitor Withdrawals: The service listens for WithdrawalProven events on the OptimismPortal contract on L1.
 - Validate Withdrawals: It verifies the validity of these withdrawals by checking the corresponding state on L2.
 - Detect Forgeries: The service identifies and reports any invalid withdrawals or potential forgeries.

--- a/op-monitorism/withdrawals/README.md
+++ b/op-monitorism/withdrawals/README.md
@@ -1,5 +1,5 @@
 # Purpose of the Service
-withdrawals has the following purpose:
+Withdrawal has the following purpose:
 - Monitor Withdrawals: The service listens for WithdrawalProven events on the OptimismPortal contract on L1.
 - Validate Withdrawals: It verifies the validity of these withdrawals by checking the corresponding state on L2.
 - Detect Forgeries: The service identifies and reports any invalid withdrawals or potential forgeries.


### PR DESCRIPTION
**Description**

A minor grammatical error was identified in the introductory section of the withdrawal monitor documentation. The sentence:  

> "withdrawals has the following purpose:"  

incorrectly uses the plural *withdrawals* with the singular verb *has*. To align the subject and verb, the plural *withdrawals* has been corrected to the singular *withdrawal*:  

> "Withdrawal has the following purpose:"  

### Reason:
- The verb *has* requires a singular subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated section header from "withdrawals" to "Withdrawals" in the README file.
	- Improved formatting consistency by adding a newline at the end of the bash options section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->