### PR TITLE
docs: Fix grammar and phrasing issues Update README.md

### DIFF
--- a/op-monitorism/global_events/README.md
+++ b/op-monitorism/global_events/README.md
@@ -1,9 +1,9 @@
 # Global Events Monitoring
 
-This monitoring modules is made for to taking YAML rules as configuration.
+This monitoring module is made for taking YAML rules as configuration.
 ![df2b94999628ce8eee98fb60f45667e54be9b13db82add6aa77888f355137329](https://github.com/ethereum-optimism/monitorism/assets/23560242/b8d36a0f-8a17-4e22-be5a-3e9f3586b3ab)
 
-Once the Yaml rules is configured correctly, we can listen to an event chosen to send the data through prometheus.
+Once the YAML rules are configured correctly, we can listen to an event chosen to send the data through prometheus.
 
 ## CLI and Docs:
 
@@ -40,7 +40,7 @@ The rules are located here: `op-monitorism/global_events/rules/`. Then we have m
 
 ```yaml
 # This is a TEMPLATE file please copy this one
-# This watches all contacts for OP, Mode, and Base mainnets for two logs.
+# This watches all contracts for OP, Mode, and Base mainnets for two logs.
 version: 1.0
 name: Template SafeExecution Events (Success/Failure) L1 # Please put the L1 or L2 at the end of the name.
 priority: P5 # This is a test, so it is a P5


### PR DESCRIPTION
**Description**

This update corrects several grammatical and phrasing issues in the documentation and code comments:

- "monitoring modules is made for to taking YAML rules as configuration" has been updated to "monitoring module is made for taking YAML rules as configuration". The word "modules" was incorrect as the subject should be singular, and "made for to taking" was adjusted to the proper phrasing "made for taking".
  
- "Yaml rules is configured" has been corrected to "YAML rules are configured". The term "YAML" is now in uppercase as per the correct convention, and the verb "is" has been changed to "are" to match the plural subject "rules".

- The phrase "contacts for OP" has been corrected to "contracts for OP" to reflect the accurate term.

Thanks for **OP**!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved grammatical accuracy and clarity in the Global Events Monitoring module's README.md file.
	- Ensured consistent formatting of "YAML" throughout the document.
	- Clarified terminology in the YAML rules section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->