### PR TITLE
feat: use ci runner for go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.48.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.55.0
   ci_builder_rust_image:
     type: string
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder-rust:latest
@@ -66,9 +66,8 @@ jobs:
         type: string
         default: ""
     shell: /bin/bash -eo pipefail
-    executor:
-      name: go/default # is based on cimg/go
-      tag: "1.21"
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
     steps:
       - checkout
       - run:
@@ -95,8 +94,6 @@ jobs:
       - run:
           name: run Go linter
           command: |
-            # Identify how many cores it defaults to
-            golangci-lint --help | grep concurrency
             make <<parameters.project_name>>-lint-go
           working_directory: .
       - save_cache:


### PR DESCRIPTION
Updates our go tests to use the ci runner so that we can run tests that rely on anvil and other forge utilities.