### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/op-monitorism/transaction_monitor/README.md
+++ b/op-monitorism/transaction_monitor/README.md
@@ -32,7 +32,7 @@ watch_configs:
       "0x1234567890123456789012345678901234567890": "1000000000000000000"
 ```
 
-* A `start_block` set to `0` indicates latest block. 
+* A `start_block` set to `0` indicates the latest block. 
 
 ## Metrics
 


### PR DESCRIPTION
**Description**

The typo is in this sentence:

> "A `start_block` set to `0` indicates latest block."

Correction: 

> "A `start_block` set to `0` indicates the latest block."

Fixed.

