### PR TITLE
docs: Fix inconsistency in Faultproof Withdrawals table link format U…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This component is designed to work exclusively with chains that are already util
 This is a new version of the deprecated [chain-mon faultproof-wd-mon](https://github.com/ethereum-optimism/optimism/tree/chain-mon/v1.2.1/packages/chain-mon/src/faultproof-wd-mon).
 For detailed information on how the component works and the algorithms used, please refer to the component README.
 
-| `op-monitorism/faultproof-withdrawals` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/faultproof_withdrawals/README.md) |
+| `op-monitorism/faultproof_withdrawals` | [README](https://github.com/ethereum-optimism/monitorism/blob/main/op-monitorism/faultproof_withdrawals/README.md) |
 | ----------------------- | --------------------------------------------------------------------------------------------------- |
 
 


### PR DESCRIPTION
**Description**

<img width="441" alt="Снимок экрана 2024-12-23 в 21 56 56" src="https://github.com/user-attachments/assets/13dea685-ec99-4826-9049-620f58b75a63" />

I noticed an inconsistency in the `Faultproof Withdrawals` section. The table header references `faultproof-withdrawals` using a hyphen (`-`), but the corresponding link to the `README.md` file uses `faultproof_withdrawals` with an underscore (`_`).  

Corrected.