### PR TITLE
fix: broken link CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Before opening a PR:
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
 1. Update the README.md if your changes invalidate or extend its current content.
 1. Include tests for any new functionality.
-1. Ensure each section of the [Pull Request Template](./PULL_REQUEST_TEMPLATE.md) is filled out. Delete any sections that are not relevant.
+1. Ensure each section of the [Pull Request Template](https://github.com/ethereum-optimism/.github/blob/master/PULL_REQUEST_TEMPLATE.md) is filled out. Delete any sections that are not relevant.
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
 


### PR DESCRIPTION
## Description  
Updated the link to the pull request template in `CONTRIBUTING.md` to point to the correct location:  
`https://github.com/ethereum-optimism/.github/blob/master/PULL_REQUEST_TEMPLATE.md`.

## Tests  
No automated tests were added as this is a documentation update. Verified the updated link manually to ensure it works correctly.

## Additional Context  
This update ensures contributors are directed to the correct pull request template for consistency in submissions.

## Metadata  
- Fixes: None (no related issue linked)