### PR TITLE
docs: Fix typo in --accounts parameter description

### DIFF
--- a/op-monitorism/balances/README.md
+++ b/op-monitorism/balances/README.md
@@ -5,5 +5,5 @@ The balances monitor simply emits a metric reporting the balances for the config
 ```
 OPTIONS:
    --node.url value                                             [$BALANCE_MON_NODE_URL]  Node URL of a peer (default: "127.0.0.1:8545")
-   --accounts address:nickname [ --accounts address:nickname ]  [$BALANCE_MON_ACCOUNTS]  One or accounts formatted via address:nickname
+   --accounts address:nickname [ --accounts address:nickname ]  [$BALANCE_MON_ACCOUNTS]  One or more accounts formatted via address:nickname
 ```


### PR DESCRIPTION
**Description**

I noticed a typo in the description for the `--accounts` parameter. The phrase "One or accounts" seems to be missing the word "more."

I've updated it to "**One or more accounts**" for clarity and correctness.  
