### PR TITLE
fix typo Update README.md

### DIFF
--- a/op-defender/psp_executor/README.md
+++ b/op-defender/psp_executor/README.md
@@ -30,7 +30,7 @@ Explanation of the options:
 | Argument | Value | Explanation |
 | ---------------------------- | ------------------------------------------ | ------------------------------------ |
 | `--privatekey` | 2a[..]c6 | Private key for transaction signing |
-| `--safe.address` | 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E | Address of the Safe contract that presigned the transation|
+| `--safe.address` | 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E | Address of the Safe contract that presigned the transaction|
 | `--path` | /tmp/psps.json | Path to JSON file containing PSPs |
 | `--chainid` | 11155111 | Chain ID for the network |
 | `--superchainconfig.address` | 0xC2Be75506d5724086DEB7245bd260Cc9753911Be | Address of SuperchainConfig contract |


### PR DESCRIPTION
# Fix Typo in README.md

## Description

This pull request corrects a typo in the `README.md` file located in `op-defender/psp_executor/`. The word **transation** was corrected to **transaction** in the explanation of the `--safe.address` argument.

### Original:
> Address of the Safe contract that presigned the transation

### Fixed:
> Address of the Safe contract that presigned the transaction

## Changes Made
- Corrected the typo on line 30 of `README.md`.

## Checklist
- [x] Verified that the correction maintains the intended meaning.
- [x] Proofread the surrounding text for consistency and clarity.

---

Let me know if further adjustments are required. Thank you!
