### PR TITLE
feat: added ca-certificates so docker can connect within tailscale

### DIFF
--- a/op-monitorism/Dockerfile
+++ b/op-monitorism/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.22.2-alpine3.19 as builder
 WORKDIR /app
 
 # Install system dependencies including 'make'
-RUN apk update && apk add --no-cache make && apk add --no-cache ca-certificates
+RUN apk update && apk add --no-cache make
 
 # Copy the source code and Makefile into the container
 COPY . .
@@ -15,6 +15,9 @@ RUN make
 
 # Define the final base image
 FROM alpine:3.18
+
+# Install ca-certificates so that HTTPS works
+RUN apk update && apk add --no-cache ca-certificates
 
 # Copy the built binary from the builder stage
 COPY --from=builder /app/bin/monitorism /usr/local/bin/monitorism

--- a/op-monitorism/Dockerfile
+++ b/op-monitorism/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.22.2-alpine3.19 as builder
 WORKDIR /app
 
 # Install system dependencies including 'make'
-RUN apk update && apk add --no-cache make
+RUN apk update && apk add --no-cache make && apk add --no-cache ca-certificates
 
 # Copy the source code and Makefile into the container
 COPY . .


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Doing some testing with @jelias2 and we discovered that in order for monitorism to be able to connect within the cluster, it needs ca-certificates installed on the image

**Tests**

No tests added, the image builds and its a simple package install

