### PR TITLE
feat: Add 'up' gauge metric to track service status for faultproof_withdrawals

### DIFF
--- a/op-monitorism/faultproof_withdrawals/state.go
+++ b/op-monitorism/faultproof_withdrawals/state.go
@@ -176,6 +176,7 @@ func (s *State) GetPercentages() (uint64, uint64) {
 }
 
 type Metrics struct {
+	UpGauge              prometheus.Gauge
 	InitialL1HeightGauge prometheus.Gauge
 	NextL1HeightGauge    prometheus.Gauge
 	LatestL1HeightGauge  prometheus.Gauge
@@ -201,6 +202,7 @@ type Metrics struct {
 }
 
 func (m *Metrics) String() string {
+	upGaugeValue, _ := GetGaugeValue(m.UpGauge)
 	initialL1HeightGaugeValue, _ := GetGaugeValue(m.InitialL1HeightGauge)
 	nextL1HeightGaugeValue, _ := GetGaugeValue(m.NextL1HeightGauge)
 	latestL1HeightGaugeValue, _ := GetGaugeValue(m.LatestL1HeightGauge)
@@ -218,7 +220,8 @@ func (m *Metrics) String() string {
 	invalidProposalWithdrawalsEventsGaugeVecValue, _ := GetGaugeVecValue(m.PotentialAttackOnInProgressGamesGaugeVec, prometheus.Labels{})
 
 	return fmt.Sprintf(
-		"InitialL1HeightGauge: %d\nNextL1HeightGauge: %d\nLatestL1HeightGauge: %d\n latestL2HeightGaugeValue: %d\n eventsProcessedCounterValue: %d\nwithdrawalsProcessedCounterValue: %d\nnodeConnectionFailuresCounterValue: %d\n potentialAttackOnDefenderWinsGamesGaugeValue: %d\n potentialAttackOnInProgressGamesGaugeValue: %d\n  forgeriesWithdrawalsEventsGaugeVecValue: %d\n invalidProposalWithdrawalsEventsGaugeVecValue: %d\n previousEventsProcessed: %d\n previousWithdrawalsProcessed: %d\n previousNodeConnectionFailures: %d\n",
+		"Up: %d\nInitialL1HeightGauge: %d\nNextL1HeightGauge: %d\nLatestL1HeightGauge: %d\n latestL2HeightGaugeValue: %d\n eventsProcessedCounterValue: %d\nwithdrawalsProcessedCounterValue: %d\nnodeConnectionFailuresCounterValue: %d\n potentialAttackOnDefenderWinsGamesGaugeValue: %d\n potentialAttackOnInProgressGamesGaugeValue: %d\n  forgeriesWithdrawalsEventsGaugeVecValue: %d\n invalidProposalWithdrawalsEventsGaugeVecValue: %d\n previousEventsProcessed: %d\n previousWithdrawalsProcessed: %d\n previousNodeConnectionFailures: %d\n",
+		uint64(upGaugeValue),
 		uint64(initialL1HeightGaugeValue),
 		uint64(nextL1HeightGaugeValue),
 		uint64(latestL1HeightGaugeValue),
@@ -273,6 +276,11 @@ func GetGaugeVecValue(gaugeVec *prometheus.GaugeVec, labels prometheus.Labels) (
 
 func NewMetrics(m metrics.Factory) *Metrics {
 	ret := &Metrics{
+		UpGauge: m.NewGauge(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "up",
+			Help:      "1 if the service is up and running, 0 otherwise",
+		}),
 		InitialL1HeightGauge: m.NewGauge(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
 			Name:      "initial_l1_height",
@@ -349,10 +357,16 @@ func NewMetrics(m metrics.Factory) *Metrics {
 		),
 	}
 
+	// Set the up gauge to 1 to indicate the service is running
+	ret.UpGauge.Set(1)
+
 	return ret
 }
 
 func (m *Metrics) UpdateMetricsFromState(state *State) {
+
+	// Set the up gauge to 1 to indicate the service is running
+	m.UpGauge.Set(1)
 
 	// Update Gauges
 	m.InitialL1HeightGauge.Set(float64(state.initialL1Height))

--- a/op-monitorism/faultproof_withdrawals/state.go
+++ b/op-monitorism/faultproof_withdrawals/state.go
@@ -357,9 +357,6 @@ func NewMetrics(m metrics.Factory) *Metrics {
 		),
 	}
 
-	// Set the up gauge to 1 to indicate the service is running
-	ret.UpGauge.Set(1)
-
 	return ret
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes changes to the `op-monitorism/faultproof_withdrawals/state.go` file to introduce a new gauge metric for monitoring the service status. The most important changes include the addition of the `UpGauge` metric and its integration into the existing metrics structure and methods.

Introduction of `UpGauge` metric:

* [`op-monitorism/faultproof_withdrawals/state.go`](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR179): Added `UpGauge` to the `Metrics` struct to monitor if the service is up and running.
* [`op-monitorism/faultproof_withdrawals/state.go`](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR279-R283): Initialized `UpGauge` in the `NewMetrics` function and set its value to 1 to indicate the service is running. [[1]](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR279-R283) [[2]](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR360-R370)

Integration into existing methods:

* [`op-monitorism/faultproof_withdrawals/state.go`](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR205): Updated the `String` method of the `Metrics` struct to include the `UpGauge` value in the output. [[1]](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bR205) [[2]](diffhunk://#diff-c5799769a4a261d24d0525cbca1b63a12df911f2fcbb2068c2b3e2b69e74547bL221-R224)

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
