### PR TITLE
test: replace log.New() with testlog.Logger in psp_executor tests

### DIFF
--- a/op-defender/psp_executor/api_test.go
+++ b/op-defender/psp_executor/api_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -58,7 +59,7 @@ func GeneratePrivatekey(size int) string {
 // TestHTTPServerHasCorrectRoute tests if the HTTP server has the correct route with "/api/psp_execution" path and "POST" method and the "/api/healthcheck" path and "GET" method.
 func TestHTTPServerHasCorrectRoute(t *testing.T) {
 	// Mock dependencies or create real ones depending on your test needs
-	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
+	logger := testlog.Logger(t, log.LvlInfo)
 	executor := &SimpleExecutor{}
 	metricsfactory := opmetrics.With(opmetrics.NewRegistry())
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
@@ -116,7 +117,7 @@ func TestHTTPServerHasCorrectRoute(t *testing.T) {
 // TestDefenderInitialization tests the initialization of the Defender struct with mock dependencies.
 func TestDefenderInitialization(t *testing.T) {
 	// Mock dependencies or create real ones depending on your test needs
-	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
+	logger := testlog.Logger(t, log.LvlInfo)
 	executor := &SimpleExecutor{}
 	metricsfactory := opmetrics.With(opmetrics.NewRegistry())
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
@@ -141,7 +142,7 @@ func TestDefenderInitialization(t *testing.T) {
 // TestHandlePostMockFetch tests the handlePost function with HTTP status code to make sure HTTP code returned are expected in every possible cases.
 func TestHandlePostMockFetch(t *testing.T) {
 	// Initialize the Defender with necessary mock or real components
-	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
+	logger := testlog.Logger(t, log.LvlInfo)
 	metricsRegistry := opmetrics.NewRegistry()
 	metricsfactory := opmetrics.With(metricsRegistry)
 	mockNodeUrl := "http://rpc.tenderly.co/fork/" // Need to have the "fork" in the URL to avoid mistake for now.
@@ -664,8 +665,7 @@ func TestGetNonceSafe(t *testing.T) {
 	safeAddressSepoliaBindings, _ := bindings.NewSafe(common.HexToAddress(safeAddressSepolia), l1ClientSepolia)
 
 	// Initialize the Defender with necessary mock or real components
-	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
-
+	logger := testlog.Logger(t, log.LvlInfo)
 	metricsRegistry_mainnet := opmetrics.NewRegistry()
 	metricsRegistry_sepolia := opmetrics.NewRegistry()
 	metricsRegistry_sepolia_error := opmetrics.NewRegistry()
@@ -850,7 +850,7 @@ func TestCheckPauseStatus(t *testing.T) {
 	superChainAddressSepoliaBindings, _ := bindings.NewSuperchainConfig(common.HexToAddress(superChainAddressSepolia), l1ClientSepolia)
 
 	// Initialize the Defender with necessary mock or real components
-	logger := log.New() //@TODO: replace with testlog  https://github.com/ethereum-optimism/optimism/blob/develop/op-service/testlog/testlog.go#L61
+	logger := testlog.Logger(t, log.LvlInfo)
 	metricsRegistry_mainnet := opmetrics.NewRegistry()
 	metricsRegistry_sepolia := opmetrics.NewRegistry()
 	metricsRegistry_sepolia_error := opmetrics.NewRegistry()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR replaces the standard logger (`log.New()`) with `testlog.Logger` in the `op-defender/psp_executor/api_test.go` test file. This change improves test output handling by:
- Only showing logs when tests fail or when running with -v flag
- Including test context in log output
- Properly handling log levels

The change addresses multiple TODO comments in the codebase regarding logger replacement in test files.

**Tests**

The changes were made directly to test files, specifically:
- Updated logger initialization in `TestHTTPServerHasCorrectRoute`
- Updated logger initialization in `TestDefenderInitialization`
- Updated logger initialization in `TestHandlePostMockFetch`
- Updated logger initialization in `TestGetNonceSafe`
- Updated logger initialization in `TestCheckPauseStatus`

All existing tests continue to pass with the new logger implementation.

**Additional context**

This change is part of a larger effort to standardize test logging across the codebase using `testlog`. The `testlog` package is specifically designed for test environments and provides better control over log output during test execution.

**Metadata**

- Fixes TODO comments regarding logger replacement in test files
- Improves test output clarity and debugging experience