### PR TITLE
fix: Improve logging and fix function

### DIFF
--- a/op-monitorism/faultproof_withdrawals/validator/op_node_helper.go
+++ b/op-monitorism/faultproof_withdrawals/validator/op_node_helper.go
@@ -78,7 +78,7 @@ func (on *OpNodeHelper) GetOutputRootFromTrustedL2Node(l2blockNumber *big.Int) (
 		err := on.rpc_l2Client.CallContext(on.ctx, &result, "optimism_outputAtBlock", l2blockNumberHex)
 		//check if error contains "failed to determine L2BlockRef of height"
 		if err != nil {
-			return [32]byte{}, fmt.Errorf("failed to get output at block for game block:%v : %w", l2blockNumberHex, err)
+			return [32]byte{}, fmt.Errorf("failed to get output at block for game blockHex:%v blockInt:%v error:%w", l2blockNumberHex, l2blockNumber, err)
 		}
 		trustedRootProof, err := StringToBytes32(result.OutputRoot)
 		if err != nil {
@@ -94,13 +94,14 @@ func (on *OpNodeHelper) GetOutputRootFromTrustedL2Node(l2blockNumber *big.Int) (
 // GetOutputRootFromCalculation retrieves the output root by calculating it from the given block number.
 // It returns the calculated output root as a Bytes32 array.
 func (on *OpNodeHelper) GetOutputRootFromCalculation(blockNumber *big.Int) ([32]byte, error) {
-	block, err := on.l2OpNodeClient.BlockByNumber(on.ctx, blockNumber)
+	fmt.Println("Getting output root from calculation for block number:", blockNumber)
+	block, err := on.l2OpGethClient.BlockByNumber(on.ctx, blockNumber)
 	if err != nil {
-		return [32]byte{}, fmt.Errorf("failed to get block by number: %w", err)
+		return [32]byte{}, fmt.Errorf("failed to get output at block for game blockInt:%v error:%w", blockNumber, err)
 	}
 
 	proof := struct{ StorageHash common.Hash }{}
-	err = on.l2OpNodeClient.Client().CallContext(on.ctx, &proof, "eth_getProof", predeploys.L2ToL1MessagePasserAddr, nil, hexutil.EncodeBig(blockNumber))
+	err = on.l2OpGethClient.Client().CallContext(on.ctx, &proof, "eth_getProof", predeploys.L2ToL1MessagePasserAddr, nil, hexutil.EncodeBig(blockNumber))
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("failed to get proof: %w", err)
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This pull request includes changes to improve error messages and logging in the `op-monitorism/faultproof_withdrawals/validator/op_node_helper.go` file. The most important changes include enhancing error messages with additional context and adding a debug print statement.

Improvements to error messages and logging:

* Enhanced the error message in the `GetOutputRootFromTrustedL2Node` method to include both the hexadecimal and integer representations of the block number.
* Added a debug print statement in the `GetOutputRootFromCalculation` method to log the block number being processed.
* Updated the error message in the `GetOutputRootFromCalculation` method to include the integer representation of the block number.
* Changed the client used in the `GetOutputRootFromCalculation` method from `l2OpNodeClient` to `l2OpGethClient` for retrieving block information and proof.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
