### PR TITLE
feat(op-monitorism): enhance logs on the monitor

### DIFF
--- a/op-monitorism/faultproof_withdrawals/monitor.go
+++ b/op-monitorism/faultproof_withdrawals/monitor.go
@@ -41,15 +41,18 @@ type Monitor struct {
 // It establishes connections to the specified L1 and L2 Geth clients, initializes
 // the withdrawal validator, and sets up the initial state and metrics.
 func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig) (*Monitor, error) {
-	log.Info("creating withdrawals monitor...")
+	log.Info("Creating withdrawals monitor...")
 
+	log.Debug("Initializing L1 client connection", "url", cfg.L1GethURL)
 	l1GethClient, err := ethclient.Dial(cfg.L1GethURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial l1: %w", err)
 	}
+	log.Debug("Successfully connected to L1 client")
 
 	mapL2GethBackupURLs := make(map[string]string)
 	if len(cfg.L2GethBackupURLs) > 0 {
+		log.Debug("Processing L2 backup URLs", "count", len(cfg.L2GethBackupURLs))
 		for _, part := range cfg.L2GethBackupURLs {
 			parts := strings.Split(part, "=")
 			if len(parts) != 2 {
@@ -57,20 +60,30 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 			}
 			name, url := parts[0], parts[1]
 			mapL2GethBackupURLs[name] = url
+			log.Debug("Added L2 backup URL", "name", name, "url", url)
 		}
 	}
 
+	log.Debug("Creating withdrawal validator",
+		"l1Url", cfg.L1GethURL,
+		"l2Url", cfg.L2OpGethURL,
+		"backupUrls", len(mapL2GethBackupURLs),
+		"portalAddress", cfg.OptimismPortalAddress)
 	withdrawalValidator, err := validator.NewWithdrawalValidator(ctx, log, cfg.L1GethURL, cfg.L2OpGethURL, mapL2GethBackupURLs, cfg.OptimismPortalAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create withdrawal validator: %w", err)
 	}
+	log.Debug("Successfully created withdrawal validator")
 
+	log.Debug("Querying latest L1 block number")
 	latestL1Height, err := l1GethClient.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query latest block number: %w", err)
 	}
+	log.Debug("Retrieved latest L1 block number", "height", latestL1Height)
 
 	metrics := NewMetrics(m)
+	log.Debug("Initialized metrics")
 
 	ret := &Monitor{
 		log: log,
@@ -85,39 +98,52 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 	}
 
 	// is starting block is set it takes precedence
-
 	var startingL1BlockHeight uint64
 	hoursInThePastToStartFrom := cfg.HoursInThePastToStartFrom
 
 	// In this case StartingL1BlockHeight is not set
 	if cfg.StartingL1BlockHeight == -1 {
+		log.Debug("Starting block height not set, calculating from hours in past",
+			"hoursInPast", hoursInThePastToStartFrom,
+			"defaultHours", DefaultHoursInThePastToStartFrom)
+
 		// in this case is not set how many hours in the past to start from, we use default value that is 14 days.
 		if hoursInThePastToStartFrom == 0 {
 			hoursInThePastToStartFrom = DefaultHoursInThePastToStartFrom
+			log.Debug("Using default hours in past", "hours", DefaultHoursInThePastToStartFrom)
 		}
 
 		// get the block number closest to the timestamp from two weeks ago
 		latestL1HeightBigInt := new(big.Int).SetUint64(latestL1Height)
+		log.Debug("Searching for block at approximate time",
+			"latestHeight", latestL1HeightBigInt.String(),
+			"hoursInPast", hoursInThePastToStartFrom)
 		startingL1BlockHeightBigInt, err := ret.getBlockAtApproximateTimeBinarySearch(ctx, l1GethClient, latestL1HeightBigInt, big.NewInt(int64(hoursInThePastToStartFrom)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get block at approximate time: %w", err)
 		}
 		startingL1BlockHeight = startingL1BlockHeightBigInt.Uint64()
-
+		log.Debug("Found starting block height", "height", startingL1BlockHeight)
 	} else {
 		startingL1BlockHeight = uint64(cfg.StartingL1BlockHeight)
+		log.Debug("Using provided starting block height", "height", startingL1BlockHeight)
 	}
 
+	log.Debug("Querying latest L2 block number")
 	latestL2Height, err := ret.withdrawalValidator.GetL2BlockNumber()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest L2 height: %w", err)
 	}
+	log.Debug("Retrieved latest L2 block number", "height", latestL2Height)
 
 	if startingL1BlockHeight > latestL1Height {
-		log.Info("nextL1Height is greater than latestL1Height, starting from latest", "nextL1Height", startingL1BlockHeight, "latestL1Height", latestL1Height)
+		log.Info("Next L1 height is greater than latest L1 height, starting from latest",
+			"nextL1Height", startingL1BlockHeight,
+			"latestL1Height", latestL1Height)
 		startingL1BlockHeight = latestL1Height
 	}
 
+	log.Debug("Creating initial state")
 	state, err := NewState(log, withdrawalValidator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create state: %w", err)
@@ -132,6 +158,12 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 	// log state and metrics
 	ret.state.LogState()
 	ret.metrics.UpdateMetricsFromState(&ret.state)
+
+	log.Info("Successfully initialized monitor",
+		"startingL1Height", startingL1BlockHeight,
+		"latestL1Height", latestL1Height,
+		"latestL2Height", latestL2Height,
+		"maxBlockRange", cfg.EventBlockRange)
 
 	return ret, nil
 }
@@ -155,6 +187,12 @@ func (m *Monitor) getBlockAtApproximateTimeBinarySearch(ctx context.Context, cli
 	var mid *big.Int
 	acceptablediff := big.NewInt(60 * 60) //60 minutes
 
+	m.log.Debug("Starting binary search",
+		"targetTime", time.Unix(targetTime.Int64(), 0).Format("2006-01-02 15:04:05 MST"),
+		"leftBound", left.String(),
+		"rightBound", right.String(),
+		"acceptableDiffSeconds", acceptablediff.String())
+
 	// Perform binary search
 	for left.Cmp(right) <= 0 {
 		//interrupt in case of context cancellation
@@ -168,33 +206,55 @@ func (m *Monitor) getBlockAtApproximateTimeBinarySearch(ctx context.Context, cli
 		mid = new(big.Int).Add(left, right)
 		mid.Div(mid, big.NewInt(2))
 
+		m.log.Debug("Binary search iteration",
+			"left", left.String(),
+			"right", right.String(),
+			"mid", mid.String())
+
 		// Get the block at mid
 		block, err := client.BlockByNumber(context.Background(), mid)
 		if err != nil {
+			m.log.Error("Failed to get block", "blockNumber", mid.String(), "error", err)
 			return nil, err
 		}
 
 		// Check the block's timestamp
 		blockTime := big.NewInt(int64(block.Time()))
+		blockTimeFormatted := time.Unix(blockTime.Int64(), 0).Format("2006-01-02 15:04:05 MST")
 
 		//calculate the difference between the block time and the target time
 		diff := new(big.Int).Sub(blockTime, targetTime)
+		diffHours := new(big.Int).Div(diff, big.NewInt(3600))
+
+		m.log.Debug("Block time comparison",
+			"blockNumber", mid.String(),
+			"blockTime", blockTimeFormatted,
+			"timeDiffHours", diffHours.String(),
+			"timeDiffSeconds", diff.String())
 
 		// If block time is less than or equal to target time, check if we need to search to the right
 		if blockTime.Cmp(targetTime) <= 0 {
 			left.Set(mid) // Move left boundary up to mid
+			m.log.Debug("Moving left boundary up", "newLeft", left.String())
 		} else {
 			right.Sub(mid, big.NewInt(1)) // Move right boundary down
+			m.log.Debug("Moving right boundary down", "newRight", right.String())
 		}
 		if new(big.Int).Abs(diff).Cmp(acceptablediff) <= 0 {
 			//if the difference is less than or equal to 1 hour, we can consider this block as the block closest to the target time
+			m.log.Debug("Found acceptable block",
+				"blockNumber", mid.String(),
+				"blockTime", blockTimeFormatted,
+				"timeDiffHours", diffHours.String())
 			break
 		}
-
 	}
 
 	// log the block number closest to the target time and the time
-	m.log.Info("block number closest to target time", "block", fmt.Sprintf("%v", left), "time", time.Unix(targetTime.Int64(), 0))
+	m.log.Info("Found block closest to target time",
+		"block", left.String(),
+		"time", time.Unix(targetTime.Int64(), 0).Format("2006-01-02 15:04:05 MST"),
+		"blockTime", time.Unix(targetTime.Int64(), 0).Format("2006-01-02 15:04:05 MST"))
 	// After exiting the loop, left should be the block number closest to the target time
 	return left, nil
 }
@@ -202,17 +262,24 @@ func (m *Monitor) getBlockAtApproximateTimeBinarySearch(ctx context.Context, cli
 // GetLatestBlock retrieves the latest block number from the L1 Geth client.
 // It updates the state with the latest L1 height.
 func (m *Monitor) GetLatestBlock() (uint64, error) {
+	m.log.Debug("Getting latest L1 block number")
 	latestL1Height, err := m.withdrawalValidator.GetL1BlockNumber()
 	if err != nil {
+		m.log.Error("Failed to query latest block number", "error", err)
 		return 0, fmt.Errorf("failed to query latest block number: %w", err)
 	}
 	m.state.latestL1Height = latestL1Height
+	m.log.Debug("Updated latest L1 block number", "height", latestL1Height)
 	return latestL1Height, nil
 }
 
 // GetMaxBlock calculates the maximum block number to be processed.
 // It considers the next L1 height and the defined max block range.
 func (m *Monitor) GetMaxBlock() (uint64, error) {
+	m.log.Debug("Calculating max block number",
+		"nextL1Height", m.state.nextL1Height,
+		"maxBlockRange", m.maxBlockRange)
+
 	latestL1Height, err := m.GetLatestBlock()
 	if err != nil {
 		return 0, fmt.Errorf("failed to query latest block number: %w", err)
@@ -221,7 +288,11 @@ func (m *Monitor) GetMaxBlock() (uint64, error) {
 	stop := m.state.nextL1Height + m.maxBlockRange
 	if stop > latestL1Height {
 		stop = latestL1Height
+		m.log.Debug("Max block adjusted to latest L1 height",
+			"originalStop", m.state.nextL1Height+m.maxBlockRange,
+			"adjustedStop", stop)
 	}
+	m.log.Debug("Calculated max block number", "stop", stop)
 	return stop, nil
 }
 
@@ -233,114 +304,154 @@ func (m *Monitor) Run(ctx context.Context) {
 	defer m.state.LogState()
 
 	start := m.state.nextL1Height
+	m.log.Debug("Starting monitoring run", "startBlock", start)
 
 	stop, err := m.GetMaxBlock()
 	if err != nil {
-		m.log.Error("failed to get max block", "error", err)
+		m.log.Error("Failed to get max block", "error", err)
 		return
 	}
+	m.log.Debug("Got max block for processing", "stopBlock", stop)
 
 	// review previous invalidProposalWithdrawalsEvents
+	m.log.Debug("Processing previous potential attack events",
+		"count", len(m.state.potentialAttackOnInProgressGames))
 	err = m.ConsumeEvents(m.state.potentialAttackOnInProgressGames)
-
 	if err != nil {
-		m.log.Error("failed to consume events", "error", err)
+		m.log.Error("Failed to consume previous events", "error", err)
 		return
 	}
 
 	// get new events
-	m.log.Info("getting enriched withdrawal events", "start", fmt.Sprintf("%d", start), "stop", fmt.Sprintf("%d", stop))
+	m.log.Info("Getting enriched withdrawal events",
+		"start", start,
+		"stop", stop,
+		"range", stop-start)
 	newEvents, err := m.withdrawalValidator.GetEnrichedWithdrawalsEventsMap(start, &stop)
 
 	if err != nil {
 		if start >= stop {
-			m.log.Info("no new events to process", "start", start, "stop", stop)
+			m.log.Info("No new events to process", "start", start, "stop", stop)
 		} else if stop-start <= 1 {
-			//in this case it happens when the range is too small, we can ignore the error as it is normal for the Iterator to not be ready yet
-			m.log.Info("failed to get enriched withdrawal events, should not be an issue as start and stop blocks are too close", "error", err)
+			m.log.Info("Failed to get enriched withdrawal events, range too small",
+				"error", err,
+				"start", start,
+				"stop", stop)
 		} else {
-			m.log.Error("failed to get enriched withdrawal events", "error", err)
+			m.log.Error("Failed to get enriched withdrawal events",
+				"error", err,
+				"start", start,
+				"stop", stop)
 		}
 		return
 	}
 
+	m.log.Debug("Retrieved new withdrawal events", "count", len(newEvents))
 	err = m.ConsumeEvents(newEvents)
-
 	if err != nil {
-		m.log.Error("failed to consume events", "error", err)
+		m.log.Error("Failed to consume new events", "error", err)
 		return
 	}
 
 	// update state
+	m.log.Debug("Updating next L1 height",
+		"oldHeight", m.state.nextL1Height,
+		"newHeight", stop)
 	m.state.nextL1Height = stop
-
 }
 
 // ConsumeEvents processes a slice of enriched withdrawal events and updates their states.
 // It returns any events detected during the consumption that requires to be re-analysed again at a later stage (when the event referenced DisputeGame completes).
 func (m *Monitor) ConsumeEvents(enrichedWithdrawalEvents map[common.Hash]*validator.EnrichedProvenWithdrawalEvent) error {
-	for _, enrichedWithdrawalEvent := range enrichedWithdrawalEvents {
+	m.log.Debug("Starting to consume events", "count", len(enrichedWithdrawalEvents))
+
+	for hash, enrichedWithdrawalEvent := range enrichedWithdrawalEvents {
 		if enrichedWithdrawalEvent == nil {
-			m.log.Error("WITHDRAWAL: enrichedWithdrawalEvent is nil in ConsumeEvents")
+			m.log.Error("WITHDRAWAL: enrichedWithdrawalEvent is nil in ConsumeEvents", "hash", hash)
 			panic("WITHDRAWAL: enrichedWithdrawalEvent is nil in ConsumeEvents")
 		}
-		m.log.Info("processing withdrawal event", "event", enrichedWithdrawalEvent)
+		m.log.Debug("Processing withdrawal event",
+			"hash", hash,
+			"event", enrichedWithdrawalEvent)
+
 		err := m.withdrawalValidator.UpdateEnrichedWithdrawalEvent(enrichedWithdrawalEvent)
 		if err != nil {
-			m.log.Error("failed to update enriched withdrawal event", "error", err)
+			m.log.Error("Failed to update enriched withdrawal event",
+				"error", err,
+				"hash", hash)
 			return err
 		}
-		//upgrade state to the latest L2 height	after the event is processed
+
+		//upgrade state to the latest L2 height after the event is processed
+		m.log.Debug("Updating L2 block number after event processing")
 		m.state.latestL2Height, err = m.withdrawalValidator.GetL2BlockNumber()
 		if err != nil {
-			m.log.Error("failed to update enriched withdrawal event", "error", err)
+			m.log.Error("Failed to get L2 block number", "error", err)
 			return err
 		}
 
 		err = m.ConsumeEvent(enrichedWithdrawalEvent)
 		if err != nil {
-			m.log.Error("failed to consume event", "error", err, "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
+			m.log.Error("Failed to consume event",
+				"error", err,
+				"hash", hash,
+				"event", enrichedWithdrawalEvent)
 			return err
 		}
 	}
 
+	m.log.Debug("Finished consuming events", "processedCount", len(enrichedWithdrawalEvents))
 	return nil
 }
 
 // ConsumeEvent processes a single enriched withdrawal event.
 // It logs the event details and checks for any forgery detection.
 func (m *Monitor) ConsumeEvent(enrichedWithdrawalEvent *validator.EnrichedProvenWithdrawalEvent) error {
+	m.log.Debug("Validating withdrawal event",
+		"gameStatus", enrichedWithdrawalEvent.DisputeGame.DisputeGameData.Status)
+
 	valid, err := m.withdrawalValidator.IsWithdrawalEventValid(enrichedWithdrawalEvent)
 	if err != nil {
-		m.log.Error("failed to check if forgery detected", "error", err, "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
+		m.log.Error("Failed to check if forgery detected",
+			"error", err)
 		return err
 	}
 
 	if !valid {
 		if !enrichedWithdrawalEvent.Blacklisted {
 			if enrichedWithdrawalEvent.DisputeGame.DisputeGameData.Status == validator.CHALLENGER_WINS {
+				m.log.Debug("Incrementing suspicious events on challenger wins games")
 				m.state.IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawalEvent)
 			} else if enrichedWithdrawalEvent.DisputeGame.DisputeGameData.Status == validator.DEFENDER_WINS {
+				m.log.Debug("Incrementing potential attack on defender wins games")
 				m.state.IncrementPotentialAttackOnDefenderWinsGames(enrichedWithdrawalEvent)
 			} else if enrichedWithdrawalEvent.DisputeGame.DisputeGameData.Status == validator.IN_PROGRESS {
+				m.log.Debug("Incrementing potential attack on in-progress games")
 				m.state.IncrementPotentialAttackOnInProgressGames(enrichedWithdrawalEvent)
-				// add to events to be re-processed
 			} else {
-				m.log.Error("WITHDRAWAL: is NOT valid, game status is unknown. UNKNOWN STATE SHOULD NEVER HAPPEN", "enrichedWithdrawalEvent", enrichedWithdrawalEvent)
+				m.log.Error("WITHDRAWAL: is NOT valid, game status is unknown",
+					"status", enrichedWithdrawalEvent.DisputeGame.DisputeGameData.Status)
 			}
-
 		} else {
+			m.log.Debug("Incrementing suspicious events on blacklisted event")
 			m.state.IncrementSuspiciousEventsOnChallengerWinsGames(enrichedWithdrawalEvent)
 		}
 	} else {
+		m.log.Debug("Incrementing validated withdrawals")
 		m.state.IncrementWithdrawalsValidated(enrichedWithdrawalEvent)
 	}
+
 	m.state.eventsProcessed++
 	m.metrics.UpdateMetricsFromState(&m.state)
+
+	m.log.Debug("Finished processing event",
+		"valid", valid,
+		"totalProcessed", m.state.eventsProcessed)
 	return nil
 }
 
 // Close gracefully shuts down the Monitor by closing the Geth clients.
 func (m *Monitor) Close(_ context.Context) error {
+	m.log.Debug("Closing monitor")
 	return nil
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds more debug logs on the faultproofs_withdrawal monitor.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**
We have identifed that the monitor may fail to start sometimes when it can't fetch the blocks from the RPC endpoint. This is not immediately understandable as there's not enough logs to showcase that this is the issue.
Furthermore, the service will continue to be marked as "healthy" even if it can't access the RPC.

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
