### PR TITLE
feat: withdrawal monitor v2

### DIFF
--- a/op-monitorism/conservation_monitor/monitor.go
+++ b/op-monitorism/conservation_monitor/monitor.go
@@ -71,6 +71,7 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 		cfg.NodeUrl,
 		nil,
 		mon.processBlock,
+		nil,
 		&processor.Config{
 			StartBlock: big.NewInt(int64(cfg.StartBlock)),
 			Interval:   cfg.PollingInterval,

--- a/op-monitorism/go.mod
+++ b/op-monitorism/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -66,6 +67,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
@@ -74,7 +76,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/op-monitorism/processor/processor.go
+++ b/op-monitorism/processor/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -20,10 +21,16 @@ type TxProcessingFunc func(block *types.Block, tx *types.Transaction, client *et
 // TxProcessingFunc is the type for block processing functions
 type BlockProcessingFunc func(block *types.Block, client *ethclient.Client) error
 
+// LogProcessingFunc is the type for log processing functions (invoked per log)
+type LogProcessingFunc func(block *types.Block, lg types.Log, client *ethclient.Client) error
+
 type Metrics struct {
 	highestBlockSeen      prometheus.Gauge
 	highestBlockProcessed prometheus.Gauge
 	processingErrors      prometheus.Counter
+	currentBackoffDelay   prometheus.Gauge
+	backoffIncreases      prometheus.Counter
+	backoffDecreases      prometheus.Counter
 }
 
 // BlockProcessor handles the monitoring and processing of Ethereum blocks
@@ -31,18 +38,39 @@ type BlockProcessor struct {
 	client           *ethclient.Client
 	txProcessFunc    TxProcessingFunc
 	blockProcessFunc BlockProcessingFunc
+	logProcessFunc   LogProcessingFunc
 	interval         time.Duration
 	lastProcessed    *big.Int
 	log              log.Logger
 	ctx              context.Context
 	cancel           context.CancelFunc
 	metrics          Metrics
+
+	// dynamic backoff state
+	currentDelay      time.Duration
+	stableCleanBlocks int
+	errorsThisBlock   int
+
+	// dynamic backoff config
+	minDelay       time.Duration
+	maxDelay       time.Duration
+	decreaseStep   time.Duration
+	stableWindow   int
+	jitterFraction float64
+	jitterRng      *rand.Rand
 }
 
 // Config holds the configuration for the processor
 type Config struct {
 	StartBlock *big.Int      // Optional: starting block number
 	Interval   time.Duration // Optional: polling interval
+
+	// Dynamic backoff configuration (optional)
+	MinDelay       time.Duration // Minimum per-block delay
+	MaxDelay       time.Duration // Maximum per-block delay
+	DecreaseStep   time.Duration // How much to decrease after stability
+	StableWindow   int           // Clean blocks before decreasing delay
+	JitterFraction float64       // +/- fraction jitter to avoid lockstep (e.g., 0.1 = +/-10%)
 }
 
 // NewBlockProcessor creates a new processor instance
@@ -52,6 +80,7 @@ func NewBlockProcessor(
 	rpcURL string,
 	txProcessFunc TxProcessingFunc,
 	blockProcessFunc BlockProcessingFunc,
+	logProcessFunc LogProcessingFunc,
 	config *Config,
 ) (*BlockProcessor, error) {
 	client, err := ethclient.Dial(rpcURL)
@@ -71,24 +100,57 @@ func NewBlockProcessor(
 		config.Interval = 12 * time.Second
 	}
 
+	// Local RNG for jitter
+	seed := time.Now().UnixNano()
+	_ = seed
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	metrics := Metrics{
 		highestBlockSeen:      m.NewGauge(prometheus.GaugeOpts{Name: "highest_block_seen"}),
 		highestBlockProcessed: m.NewGauge(prometheus.GaugeOpts{Name: "highest_block_processed"}),
 		processingErrors:      m.NewCounter(prometheus.CounterOpts{Name: "processing_errors_total"}),
+		currentBackoffDelay:   m.NewGauge(prometheus.GaugeOpts{Name: "current_backoff_delay_seconds"}),
+		backoffIncreases:      m.NewCounter(prometheus.CounterOpts{Name: "backoff_increases_total"}),
+		backoffDecreases:      m.NewCounter(prometheus.CounterOpts{Name: "backoff_decreases_total"}),
 	}
 
 	p := &BlockProcessor{
 		client:           client,
 		txProcessFunc:    txProcessFunc,
 		blockProcessFunc: blockProcessFunc,
+		logProcessFunc:   logProcessFunc,
 		interval:         config.Interval,
 		ctx:              ctx,
 		cancel:           cancel,
 		metrics:          metrics,
 		log:              log,
 	}
+
+	// Initialize RNG for jitter
+	p.jitterRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Resolve dynamic backoff config
+	if config.MaxDelay == 0 {
+		config.MaxDelay = 5 * time.Second
+	}
+	if config.DecreaseStep == 0 {
+		config.DecreaseStep = 100 * time.Millisecond
+	}
+	if config.StableWindow == 0 {
+		config.StableWindow = 5
+	}
+	if config.JitterFraction == 0 {
+		config.JitterFraction = 0.1
+	}
+
+	// Resolve dynamic backoff config.
+	p.minDelay = config.MinDelay
+	p.maxDelay = config.MaxDelay
+	p.decreaseStep = config.DecreaseStep
+	p.stableWindow = config.StableWindow
+	p.jitterFraction = config.JitterFraction
+	p.currentDelay = p.minDelay
 
 	// If starting block is specified, use it; otherwise will start from latest block
 	p.lastProcessed = config.StartBlock
@@ -99,7 +161,7 @@ func NewBlockProcessor(
 // Start begins the processing loop
 func (p *BlockProcessor) Start() error {
 	// If no starting block was specified, get the latest finalized block
-	if p.lastProcessed.Cmp(big.NewInt(0)) == 0 {
+	if p.lastProcessed == nil || p.lastProcessed.Cmp(big.NewInt(0)) == 0 {
 		block, err := p.getLatestBlock()
 		if err != nil {
 			return err
@@ -120,6 +182,9 @@ func (p *BlockProcessor) Start() error {
 				// looping. Since the processor won't increment the lastProcessed block number, it will
 				// keep trying to process the same block over and over again if necessary.
 				p.log.Error("error processing blocks", "err", err)
+
+				// Update backoff even if we had an error.
+				p.updateBackoff()
 			}
 		}
 	}
@@ -131,8 +196,13 @@ func (p *BlockProcessor) Stop() {
 }
 
 func (p *BlockProcessor) processNewBlocks() error {
+	// Reset the current error count if nonzero.
+	p.errorsThisBlock = 0
+
+	// Grab the latest block.
 	latestBlock, err := p.getLatestBlock()
 	if err != nil {
+		p.errorsThisBlock++
 		return err
 	}
 
@@ -142,38 +212,127 @@ func (p *BlockProcessor) processNewBlocks() error {
 	// Process blocks one at a time, updating lastProcessed after each
 	nextBlock := new(big.Int).Add(p.lastProcessed, common.Big1)
 	for nextBlock.Cmp(latestBlock.Number()) <= 0 {
-		p.log.Info("processing block", "block", nextBlock.String())
-
-		block, err := p.client.BlockByNumber(p.ctx, nextBlock)
-		if err != nil {
-			return fmt.Errorf("failed to get block %s: %w", nextBlock.String(), err)
+		// Process the block.
+		if err := p.processBlock(nextBlock); err != nil {
+			p.errorsThisBlock++
+			return err
 		}
 
-		// Process each transaction in the block
-		if p.txProcessFunc != nil {
-			for _, tx := range block.Transactions() {
-				if err := p.processTransactionWithRetry(block, tx); err != nil {
-					return err
-				}
-			}
-		}
+		// Update backoff after a successful block.
+		p.updateBackoff()
 
-		// Process the full block
-		if p.blockProcessFunc != nil {
-			if err := p.processBlockWithRetry(block); err != nil {
-				return err
-			}
-		}
-
-		// Update lastProcessed after each successful block
-		p.lastProcessed = new(big.Int).Set(nextBlock)
+		// Move on to the next block.
 		nextBlock.Add(nextBlock, common.Big1)
-
-		// Update highest processed block metric.
-		p.metrics.highestBlockProcessed.Set(float64(p.lastProcessed.Int64()))
 	}
 
 	return nil
+}
+
+// processBlock processes a single block and handles all errors
+func (p *BlockProcessor) processBlock(blockNumber *big.Int) error {
+	p.log.Info("processing block", "block", blockNumber.String())
+
+	// Get the block with retry
+	block, err := p.getBlockWithRetry(blockNumber)
+	if err != nil {
+		return err // Context cancellation or unrecoverable error
+	}
+
+	// Process each transaction in the block
+	if p.txProcessFunc != nil {
+		for _, tx := range block.Transactions() {
+			if err := p.processTransactionWithRetry(block, tx); err != nil {
+				return err // Context cancellation
+			}
+		}
+	}
+
+	// Process the full block
+	if p.blockProcessFunc != nil {
+		if err := p.processBlockWithRetry(block); err != nil {
+			return err // Context cancellation
+		}
+	}
+
+	// Process logs for this block via receipts
+	if p.logProcessFunc != nil {
+		receipts, err := p.getBlockReceiptsWithRetry(block)
+		if err != nil {
+			return err // Context cancellation or unrecoverable error
+		}
+		for _, rcpt := range receipts {
+			for _, lg := range rcpt.Logs {
+				if err := p.processLogWithRetry(block, *lg); err != nil {
+					return err // Context cancellation
+				}
+			}
+		}
+	}
+
+	// Update lastProcessed after successful block
+	p.lastProcessed = new(big.Int).Set(blockNumber)
+	p.metrics.highestBlockProcessed.Set(float64(p.lastProcessed.Int64()))
+
+	return nil
+}
+
+// updateBackoff adjusts the processing delay based on retry count
+func (p *BlockProcessor) updateBackoff() {
+	// Figure out if we had errors, reset error counter.
+	hadErrors := p.errorsThisBlock > 0
+	p.errorsThisBlock = 0
+
+	// If we had errors, increase the delay multiplicatively.
+	if hadErrors {
+		// If we had no delay, set it to the decrease step, otherwise double it.
+		if p.currentDelay == 0 {
+			p.currentDelay = p.decreaseStep
+		} else {
+			p.currentDelay *= 2
+		}
+
+		// Clamp the delay to the max delay.
+		if p.currentDelay > p.maxDelay {
+			p.currentDelay = p.maxDelay
+		}
+
+		// Reset the stable clean blocks counter.
+		p.stableCleanBlocks = 0
+		p.metrics.backoffIncreases.Inc()
+	} else {
+		// If we had no errors, increment the stable clean blocks counter.
+		p.stableCleanBlocks++
+
+		// If we've had no errors for the stable window, decrease the delay.
+		if p.stableCleanBlocks >= p.stableWindow && p.currentDelay > p.minDelay {
+			// Decrease the delay by the decrease step, but don't go below the min delay.
+			if p.currentDelay > p.decreaseStep+p.minDelay {
+				p.currentDelay -= p.decreaseStep
+			} else {
+				p.currentDelay = p.minDelay
+			}
+
+			// Reset the stable clean blocks counter.
+			p.stableCleanBlocks = 0
+			p.metrics.backoffDecreases.Inc()
+		}
+	}
+
+	// Update the current backoff delay metric.
+	p.metrics.currentBackoffDelay.Set(p.currentDelay.Seconds())
+	log.Info("current delay", "delay", p.currentDelay.Seconds(), "errors", p.errorsThisBlock, "stable", p.stableCleanBlocks)
+
+	// Sleep with jitter to control processing rate.
+	if p.currentDelay > 0 {
+		jitter := p.jitterFraction
+		if jitter > 0 {
+			delta := (p.jitterRng.Float64()*2 - 1) * jitter
+			sleepDur := max(time.Duration(float64(p.currentDelay)*(1+delta)), 0)
+			time.Sleep(sleepDur)
+		} else {
+			time.Sleep(p.currentDelay)
+		}
+	}
 }
 
 func (p *BlockProcessor) processTransactionWithRetry(block *types.Block, tx *types.Transaction) error {
@@ -187,6 +346,7 @@ func (p *BlockProcessor) processTransactionWithRetry(block *types.Block, tx *typ
 			} else {
 				p.log.Error("error processing transaction", "tx", tx.Hash().String(), "err", err)
 				p.metrics.processingErrors.Inc()
+				p.errorsThisBlock++
 				time.Sleep(1 * time.Second)
 			}
 		}
@@ -204,6 +364,66 @@ func (p *BlockProcessor) processBlockWithRetry(block *types.Block) error {
 			} else {
 				p.log.Error("error processing block", "block", block.Hash().String(), "err", err)
 				p.metrics.processingErrors.Inc()
+				p.errorsThisBlock++
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+}
+
+func (p *BlockProcessor) processLogWithRetry(block *types.Block, lg types.Log) error {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return p.ctx.Err()
+		default:
+			if err := p.logProcessFunc(block, lg, p.client); err == nil {
+				return nil
+			} else {
+				p.log.Error("error processing log", "block", block.Hash().String(), "logIndex", lg.Index, "txHash", lg.TxHash.Hex(), "err", err)
+				p.metrics.processingErrors.Inc()
+				p.errorsThisBlock++
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+}
+
+// getBlockWithRetry gets a block by number with retry logic
+func (p *BlockProcessor) getBlockWithRetry(blockNumber *big.Int) (*types.Block, error) {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return nil, p.ctx.Err()
+		default:
+			block, err := p.client.BlockByNumber(p.ctx, blockNumber)
+			if err == nil {
+				return block, nil
+			} else {
+				p.log.Error("error getting block", "block", blockNumber.String(), "err", err)
+				p.metrics.processingErrors.Inc()
+				p.errorsThisBlock++
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+}
+
+// getBlockReceiptsWithRetry gets block receipts with retry logic
+func (p *BlockProcessor) getBlockReceiptsWithRetry(block *types.Block) ([]*types.Receipt, error) {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return nil, p.ctx.Err()
+		default:
+			var receipts []*types.Receipt
+			err := p.client.Client().CallContext(p.ctx, &receipts, "eth_getBlockReceipts", block.Hash())
+			if err == nil {
+				return receipts, nil
+			} else {
+				p.log.Error("error getting block receipts", "block", block.Hash().String(), "err", err)
+				p.metrics.processingErrors.Inc()
+				p.errorsThisBlock++
 				time.Sleep(1 * time.Second)
 			}
 		}

--- a/op-monitorism/transaction_monitor/monitor.go
+++ b/op-monitorism/transaction_monitor/monitor.go
@@ -111,6 +111,7 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 		cfg.NodeUrl,
 		mon.processTx,
 		nil,
+		nil,
 		&processor.Config{
 			StartBlock: big.NewInt(int64(cfg.StartBlock)),
 			Interval:   cfg.PollingInterval,

--- a/op-monitorism/withdrawals-v2/bindings/FaultDisputeGame.go
+++ b/op-monitorism/withdrawals-v2/bindings/FaultDisputeGame.go
@@ -1,0 +1,1886 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TypesOutputRootProof is an auto generated low-level Go binding around an user-defined struct.
+type TypesOutputRootProof struct {
+	Version                  [32]byte
+	StateRoot                [32]byte
+	MessagePasserStorageRoot [32]byte
+	LatestBlockhash          [32]byte
+}
+
+// FaultDisputeGameMetaData contains all meta data concerning the FaultDisputeGame contract.
+var FaultDisputeGameMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"GameType\",\"name\":\"_gameType\",\"type\":\"uint32\"},{\"internalType\":\"Claim\",\"name\":\"_absolutePrestate\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"_maxGameDepth\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_splitDepth\",\"type\":\"uint256\"},{\"internalType\":\"Duration\",\"name\":\"_clockExtension\",\"type\":\"uint64\"},{\"internalType\":\"Duration\",\"name\":\"_maxClockDuration\",\"type\":\"uint64\"},{\"internalType\":\"contractIBigStepper\",\"name\":\"_vm\",\"type\":\"address\"},{\"internalType\":\"contractIDelayedWETH\",\"name\":\"_weth\",\"type\":\"address\"},{\"internalType\":\"contractIAnchorStateRegistry\",\"name\":\"_anchorStateRegistry\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_l2ChainId\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"absolutePrestate\",\"outputs\":[{\"internalType\":\"Claim\",\"name\":\"absolutePrestate_\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_ident\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_execLeafIdx\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_partOffset\",\"type\":\"uint256\"}],\"name\":\"addLocalData\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"anchorStateRegistry\",\"outputs\":[{\"internalType\":\"contractIAnchorStateRegistry\",\"name\":\"registry_\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"Claim\",\"name\":\"_disputed\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"_parentIndex\",\"type\":\"uint256\"},{\"internalType\":\"Claim\",\"name\":\"_claim\",\"type\":\"bytes32\"}],\"name\":\"attack\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"version\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"stateRoot\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"messagePasserStorageRoot\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"latestBlockhash\",\"type\":\"bytes32\"}],\"internalType\":\"structTypes.OutputRootProof\",\"name\":\"_outputRootProof\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"_headerRLP\",\"type\":\"bytes\"}],\"name\":\"challengeRootL2Block\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"}],\"name\":\"claimCredit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"claimData\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"parentIndex\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"counteredBy\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"claimant\",\"type\":\"address\"},{\"internalType\":\"uint128\",\"name\":\"bond\",\"type\":\"uint128\"},{\"internalType\":\"Claim\",\"name\":\"claim\",\"type\":\"bytes32\"},{\"internalType\":\"Position\",\"name\":\"position\",\"type\":\"uint128\"},{\"internalType\":\"Clock\",\"name\":\"clock\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"claimDataLen\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"len_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"Hash\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"claims\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"clockExtension\",\"outputs\":[{\"internalType\":\"Duration\",\"name\":\"clockExtension_\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"createdAt\",\"outputs\":[{\"internalType\":\"Timestamp\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"credit\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"Claim\",\"name\":\"_disputed\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"_parentIndex\",\"type\":\"uint256\"},{\"internalType\":\"Claim\",\"name\":\"_claim\",\"type\":\"bytes32\"}],\"name\":\"defend\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"extraData\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"extraData_\",\"type\":\"bytes\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"gameCreator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"creator_\",\"type\":\"address\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"gameData\",\"outputs\":[{\"internalType\":\"GameType\",\"name\":\"gameType_\",\"type\":\"uint32\"},{\"internalType\":\"Claim\",\"name\":\"rootClaim_\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"extraData_\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"gameType\",\"outputs\":[{\"internalType\":\"GameType\",\"name\":\"gameType_\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimIndex\",\"type\":\"uint256\"}],\"name\":\"getChallengerDuration\",\"outputs\":[{\"internalType\":\"Duration\",\"name\":\"duration_\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimIndex\",\"type\":\"uint256\"}],\"name\":\"getNumToResolve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"numRemainingChildren_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"Position\",\"name\":\"_position\",\"type\":\"uint128\"}],\"name\":\"getRequiredBond\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"requiredBond_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l1Head\",\"outputs\":[{\"internalType\":\"Hash\",\"name\":\"l1Head_\",\"type\":\"bytes32\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l2BlockNumber\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"l2BlockNumber_\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l2BlockNumberChallenged\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l2BlockNumberChallenger\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l2ChainId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"l2ChainId_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"maxClockDuration\",\"outputs\":[{\"internalType\":\"Duration\",\"name\":\"maxClockDuration_\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"maxGameDepth\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"maxGameDepth_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"Claim\",\"name\":\"_disputed\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"_challengeIndex\",\"type\":\"uint256\"},{\"internalType\":\"Claim\",\"name\":\"_claim\",\"type\":\"bytes32\"},{\"internalType\":\"bool\",\"name\":\"_isAttack\",\"type\":\"bool\"}],\"name\":\"move\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"resolutionCheckpoints\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"initialCheckpointComplete\",\"type\":\"bool\"},{\"internalType\":\"uint32\",\"name\":\"subgameIndex\",\"type\":\"uint32\"},{\"internalType\":\"Position\",\"name\":\"leftmostPosition\",\"type\":\"uint128\"},{\"internalType\":\"address\",\"name\":\"counteredBy\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"resolve\",\"outputs\":[{\"internalType\":\"enumGameStatus\",\"name\":\"status_\",\"type\":\"uint8\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_numToResolve\",\"type\":\"uint256\"}],\"name\":\"resolveClaim\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"resolvedAt\",\"outputs\":[{\"internalType\":\"Timestamp\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"resolvedSubgames\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"rootClaim\",\"outputs\":[{\"internalType\":\"Claim\",\"name\":\"rootClaim_\",\"type\":\"bytes32\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"splitDepth\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"splitDepth_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"startingBlockNumber\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"startingBlockNumber_\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"startingOutputRoot\",\"outputs\":[{\"internalType\":\"Hash\",\"name\":\"root\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"l2BlockNumber\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"startingRootHash\",\"outputs\":[{\"internalType\":\"Hash\",\"name\":\"startingRootHash_\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"status\",\"outputs\":[{\"internalType\":\"enumGameStatus\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimIndex\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"_isAttack\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"_stateData\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"_proof\",\"type\":\"bytes\"}],\"name\":\"step\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"subgames\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"vm\",\"outputs\":[{\"internalType\":\"contractIBigStepper\",\"name\":\"vm_\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"weth\",\"outputs\":[{\"internalType\":\"contractIDelayedWETH\",\"name\":\"weth_\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"parentIndex\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"Claim\",\"name\":\"claim\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"claimant\",\"type\":\"address\"}],\"name\":\"Move\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"enumGameStatus\",\"name\":\"status\",\"type\":\"uint8\"}],\"name\":\"Resolved\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"AlreadyInitialized\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AnchorRootNotFound\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BlockNumberMatches\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BondTransferFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"CannotDefendRootClaim\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ClaimAboveSplit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ClaimAlreadyExists\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ClaimAlreadyResolved\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ClockNotExpired\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ClockTimeExceeded\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ContentLengthMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"DuplicateStep\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EmptyItem\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"GameDepthExceeded\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"GameNotInProgress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"IncorrectBondAmount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidChallengePeriod\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidClockExtension\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDataRemainder\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDisputedClaimIndex\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidHeader\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidHeaderRLP\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalIdent\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidOutputRootProof\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidParent\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidPrestate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidSplitDepth\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"L2BlockNumberChallenged\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MaxDepthTooLarge\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoCreditToClaim\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OutOfOrderResolution\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnexpectedList\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"Claim\",\"name\":\"rootClaim\",\"type\":\"bytes32\"}],\"name\":\"UnexpectedRootClaim\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnexpectedString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ValidStep\",\"type\":\"error\"}]",
+}
+
+// FaultDisputeGameABI is the input ABI used to generate the binding from.
+// Deprecated: Use FaultDisputeGameMetaData.ABI instead.
+var FaultDisputeGameABI = FaultDisputeGameMetaData.ABI
+
+// FaultDisputeGame is an auto generated Go binding around an Ethereum contract.
+type FaultDisputeGame struct {
+	FaultDisputeGameCaller     // Read-only binding to the contract
+	FaultDisputeGameTransactor // Write-only binding to the contract
+	FaultDisputeGameFilterer   // Log filterer for contract events
+}
+
+// FaultDisputeGameCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FaultDisputeGameCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FaultDisputeGameTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FaultDisputeGameTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FaultDisputeGameFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FaultDisputeGameFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FaultDisputeGameSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FaultDisputeGameSession struct {
+	Contract     *FaultDisputeGame // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FaultDisputeGameCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FaultDisputeGameCallerSession struct {
+	Contract *FaultDisputeGameCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// FaultDisputeGameTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FaultDisputeGameTransactorSession struct {
+	Contract     *FaultDisputeGameTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// FaultDisputeGameRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FaultDisputeGameRaw struct {
+	Contract *FaultDisputeGame // Generic contract binding to access the raw methods on
+}
+
+// FaultDisputeGameCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FaultDisputeGameCallerRaw struct {
+	Contract *FaultDisputeGameCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FaultDisputeGameTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FaultDisputeGameTransactorRaw struct {
+	Contract *FaultDisputeGameTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFaultDisputeGame creates a new instance of FaultDisputeGame, bound to a specific deployed contract.
+func NewFaultDisputeGame(address common.Address, backend bind.ContractBackend) (*FaultDisputeGame, error) {
+	contract, err := bindFaultDisputeGame(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGame{FaultDisputeGameCaller: FaultDisputeGameCaller{contract: contract}, FaultDisputeGameTransactor: FaultDisputeGameTransactor{contract: contract}, FaultDisputeGameFilterer: FaultDisputeGameFilterer{contract: contract}}, nil
+}
+
+// NewFaultDisputeGameCaller creates a new read-only instance of FaultDisputeGame, bound to a specific deployed contract.
+func NewFaultDisputeGameCaller(address common.Address, caller bind.ContractCaller) (*FaultDisputeGameCaller, error) {
+	contract, err := bindFaultDisputeGame(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGameCaller{contract: contract}, nil
+}
+
+// NewFaultDisputeGameTransactor creates a new write-only instance of FaultDisputeGame, bound to a specific deployed contract.
+func NewFaultDisputeGameTransactor(address common.Address, transactor bind.ContractTransactor) (*FaultDisputeGameTransactor, error) {
+	contract, err := bindFaultDisputeGame(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGameTransactor{contract: contract}, nil
+}
+
+// NewFaultDisputeGameFilterer creates a new log filterer instance of FaultDisputeGame, bound to a specific deployed contract.
+func NewFaultDisputeGameFilterer(address common.Address, filterer bind.ContractFilterer) (*FaultDisputeGameFilterer, error) {
+	contract, err := bindFaultDisputeGame(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGameFilterer{contract: contract}, nil
+}
+
+// bindFaultDisputeGame binds a generic wrapper to an already deployed contract.
+func bindFaultDisputeGame(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FaultDisputeGameMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FaultDisputeGame *FaultDisputeGameRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FaultDisputeGame.Contract.FaultDisputeGameCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FaultDisputeGame *FaultDisputeGameRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.FaultDisputeGameTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FaultDisputeGame *FaultDisputeGameRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.FaultDisputeGameTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FaultDisputeGame *FaultDisputeGameCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FaultDisputeGame.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FaultDisputeGame *FaultDisputeGameTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FaultDisputeGame *FaultDisputeGameTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.contract.Transact(opts, method, params...)
+}
+
+// AbsolutePrestate is a free data retrieval call binding the contract method 0x8d450a95.
+//
+// Solidity: function absolutePrestate() view returns(bytes32 absolutePrestate_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) AbsolutePrestate(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "absolutePrestate")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// AbsolutePrestate is a free data retrieval call binding the contract method 0x8d450a95.
+//
+// Solidity: function absolutePrestate() view returns(bytes32 absolutePrestate_)
+func (_FaultDisputeGame *FaultDisputeGameSession) AbsolutePrestate() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.AbsolutePrestate(&_FaultDisputeGame.CallOpts)
+}
+
+// AbsolutePrestate is a free data retrieval call binding the contract method 0x8d450a95.
+//
+// Solidity: function absolutePrestate() view returns(bytes32 absolutePrestate_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) AbsolutePrestate() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.AbsolutePrestate(&_FaultDisputeGame.CallOpts)
+}
+
+// AnchorStateRegistry is a free data retrieval call binding the contract method 0x5c0cba33.
+//
+// Solidity: function anchorStateRegistry() view returns(address registry_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) AnchorStateRegistry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "anchorStateRegistry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AnchorStateRegistry is a free data retrieval call binding the contract method 0x5c0cba33.
+//
+// Solidity: function anchorStateRegistry() view returns(address registry_)
+func (_FaultDisputeGame *FaultDisputeGameSession) AnchorStateRegistry() (common.Address, error) {
+	return _FaultDisputeGame.Contract.AnchorStateRegistry(&_FaultDisputeGame.CallOpts)
+}
+
+// AnchorStateRegistry is a free data retrieval call binding the contract method 0x5c0cba33.
+//
+// Solidity: function anchorStateRegistry() view returns(address registry_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) AnchorStateRegistry() (common.Address, error) {
+	return _FaultDisputeGame.Contract.AnchorStateRegistry(&_FaultDisputeGame.CallOpts)
+}
+
+// ClaimData is a free data retrieval call binding the contract method 0xc6f0308c.
+//
+// Solidity: function claimData(uint256 ) view returns(uint32 parentIndex, address counteredBy, address claimant, uint128 bond, bytes32 claim, uint128 position, uint128 clock)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ClaimData(opts *bind.CallOpts, arg0 *big.Int) (struct {
+	ParentIndex uint32
+	CounteredBy common.Address
+	Claimant    common.Address
+	Bond        *big.Int
+	Claim       [32]byte
+	Position    *big.Int
+	Clock       *big.Int
+}, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "claimData", arg0)
+
+	outstruct := new(struct {
+		ParentIndex uint32
+		CounteredBy common.Address
+		Claimant    common.Address
+		Bond        *big.Int
+		Claim       [32]byte
+		Position    *big.Int
+		Clock       *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ParentIndex = *abi.ConvertType(out[0], new(uint32)).(*uint32)
+	outstruct.CounteredBy = *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+	outstruct.Claimant = *abi.ConvertType(out[2], new(common.Address)).(*common.Address)
+	outstruct.Bond = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.Claim = *abi.ConvertType(out[4], new([32]byte)).(*[32]byte)
+	outstruct.Position = *abi.ConvertType(out[5], new(*big.Int)).(**big.Int)
+	outstruct.Clock = *abi.ConvertType(out[6], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// ClaimData is a free data retrieval call binding the contract method 0xc6f0308c.
+//
+// Solidity: function claimData(uint256 ) view returns(uint32 parentIndex, address counteredBy, address claimant, uint128 bond, bytes32 claim, uint128 position, uint128 clock)
+func (_FaultDisputeGame *FaultDisputeGameSession) ClaimData(arg0 *big.Int) (struct {
+	ParentIndex uint32
+	CounteredBy common.Address
+	Claimant    common.Address
+	Bond        *big.Int
+	Claim       [32]byte
+	Position    *big.Int
+	Clock       *big.Int
+}, error) {
+	return _FaultDisputeGame.Contract.ClaimData(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ClaimData is a free data retrieval call binding the contract method 0xc6f0308c.
+//
+// Solidity: function claimData(uint256 ) view returns(uint32 parentIndex, address counteredBy, address claimant, uint128 bond, bytes32 claim, uint128 position, uint128 clock)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ClaimData(arg0 *big.Int) (struct {
+	ParentIndex uint32
+	CounteredBy common.Address
+	Claimant    common.Address
+	Bond        *big.Int
+	Claim       [32]byte
+	Position    *big.Int
+	Clock       *big.Int
+}, error) {
+	return _FaultDisputeGame.Contract.ClaimData(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ClaimDataLen is a free data retrieval call binding the contract method 0x8980e0cc.
+//
+// Solidity: function claimDataLen() view returns(uint256 len_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ClaimDataLen(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "claimDataLen")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ClaimDataLen is a free data retrieval call binding the contract method 0x8980e0cc.
+//
+// Solidity: function claimDataLen() view returns(uint256 len_)
+func (_FaultDisputeGame *FaultDisputeGameSession) ClaimDataLen() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.ClaimDataLen(&_FaultDisputeGame.CallOpts)
+}
+
+// ClaimDataLen is a free data retrieval call binding the contract method 0x8980e0cc.
+//
+// Solidity: function claimDataLen() view returns(uint256 len_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ClaimDataLen() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.ClaimDataLen(&_FaultDisputeGame.CallOpts)
+}
+
+// Claims is a free data retrieval call binding the contract method 0xeff0f592.
+//
+// Solidity: function claims(bytes32 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Claims(opts *bind.CallOpts, arg0 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "claims", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Claims is a free data retrieval call binding the contract method 0xeff0f592.
+//
+// Solidity: function claims(bytes32 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameSession) Claims(arg0 [32]byte) (bool, error) {
+	return _FaultDisputeGame.Contract.Claims(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// Claims is a free data retrieval call binding the contract method 0xeff0f592.
+//
+// Solidity: function claims(bytes32 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Claims(arg0 [32]byte) (bool, error) {
+	return _FaultDisputeGame.Contract.Claims(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ClockExtension is a free data retrieval call binding the contract method 0x6b6716c0.
+//
+// Solidity: function clockExtension() view returns(uint64 clockExtension_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ClockExtension(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "clockExtension")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// ClockExtension is a free data retrieval call binding the contract method 0x6b6716c0.
+//
+// Solidity: function clockExtension() view returns(uint64 clockExtension_)
+func (_FaultDisputeGame *FaultDisputeGameSession) ClockExtension() (uint64, error) {
+	return _FaultDisputeGame.Contract.ClockExtension(&_FaultDisputeGame.CallOpts)
+}
+
+// ClockExtension is a free data retrieval call binding the contract method 0x6b6716c0.
+//
+// Solidity: function clockExtension() view returns(uint64 clockExtension_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ClockExtension() (uint64, error) {
+	return _FaultDisputeGame.Contract.ClockExtension(&_FaultDisputeGame.CallOpts)
+}
+
+// CreatedAt is a free data retrieval call binding the contract method 0xcf09e0d0.
+//
+// Solidity: function createdAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameCaller) CreatedAt(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "createdAt")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// CreatedAt is a free data retrieval call binding the contract method 0xcf09e0d0.
+//
+// Solidity: function createdAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameSession) CreatedAt() (uint64, error) {
+	return _FaultDisputeGame.Contract.CreatedAt(&_FaultDisputeGame.CallOpts)
+}
+
+// CreatedAt is a free data retrieval call binding the contract method 0xcf09e0d0.
+//
+// Solidity: function createdAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) CreatedAt() (uint64, error) {
+	return _FaultDisputeGame.Contract.CreatedAt(&_FaultDisputeGame.CallOpts)
+}
+
+// Credit is a free data retrieval call binding the contract method 0xd5d44d80.
+//
+// Solidity: function credit(address ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Credit(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "credit", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Credit is a free data retrieval call binding the contract method 0xd5d44d80.
+//
+// Solidity: function credit(address ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameSession) Credit(arg0 common.Address) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.Credit(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// Credit is a free data retrieval call binding the contract method 0xd5d44d80.
+//
+// Solidity: function credit(address ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Credit(arg0 common.Address) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.Credit(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ExtraData is a free data retrieval call binding the contract method 0x609d3334.
+//
+// Solidity: function extraData() pure returns(bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ExtraData(opts *bind.CallOpts) ([]byte, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "extraData")
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// ExtraData is a free data retrieval call binding the contract method 0x609d3334.
+//
+// Solidity: function extraData() pure returns(bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameSession) ExtraData() ([]byte, error) {
+	return _FaultDisputeGame.Contract.ExtraData(&_FaultDisputeGame.CallOpts)
+}
+
+// ExtraData is a free data retrieval call binding the contract method 0x609d3334.
+//
+// Solidity: function extraData() pure returns(bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ExtraData() ([]byte, error) {
+	return _FaultDisputeGame.Contract.ExtraData(&_FaultDisputeGame.CallOpts)
+}
+
+// GameCreator is a free data retrieval call binding the contract method 0x37b1b229.
+//
+// Solidity: function gameCreator() pure returns(address creator_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GameCreator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "gameCreator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GameCreator is a free data retrieval call binding the contract method 0x37b1b229.
+//
+// Solidity: function gameCreator() pure returns(address creator_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GameCreator() (common.Address, error) {
+	return _FaultDisputeGame.Contract.GameCreator(&_FaultDisputeGame.CallOpts)
+}
+
+// GameCreator is a free data retrieval call binding the contract method 0x37b1b229.
+//
+// Solidity: function gameCreator() pure returns(address creator_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GameCreator() (common.Address, error) {
+	return _FaultDisputeGame.Contract.GameCreator(&_FaultDisputeGame.CallOpts)
+}
+
+// GameData is a free data retrieval call binding the contract method 0xfa24f743.
+//
+// Solidity: function gameData() view returns(uint32 gameType_, bytes32 rootClaim_, bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GameData(opts *bind.CallOpts) (struct {
+	GameType  uint32
+	RootClaim [32]byte
+	ExtraData []byte
+}, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "gameData")
+
+	outstruct := new(struct {
+		GameType  uint32
+		RootClaim [32]byte
+		ExtraData []byte
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.GameType = *abi.ConvertType(out[0], new(uint32)).(*uint32)
+	outstruct.RootClaim = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+	outstruct.ExtraData = *abi.ConvertType(out[2], new([]byte)).(*[]byte)
+
+	return *outstruct, err
+
+}
+
+// GameData is a free data retrieval call binding the contract method 0xfa24f743.
+//
+// Solidity: function gameData() view returns(uint32 gameType_, bytes32 rootClaim_, bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GameData() (struct {
+	GameType  uint32
+	RootClaim [32]byte
+	ExtraData []byte
+}, error) {
+	return _FaultDisputeGame.Contract.GameData(&_FaultDisputeGame.CallOpts)
+}
+
+// GameData is a free data retrieval call binding the contract method 0xfa24f743.
+//
+// Solidity: function gameData() view returns(uint32 gameType_, bytes32 rootClaim_, bytes extraData_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GameData() (struct {
+	GameType  uint32
+	RootClaim [32]byte
+	ExtraData []byte
+}, error) {
+	return _FaultDisputeGame.Contract.GameData(&_FaultDisputeGame.CallOpts)
+}
+
+// GameType is a free data retrieval call binding the contract method 0xbbdc02db.
+//
+// Solidity: function gameType() view returns(uint32 gameType_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GameType(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "gameType")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GameType is a free data retrieval call binding the contract method 0xbbdc02db.
+//
+// Solidity: function gameType() view returns(uint32 gameType_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GameType() (uint32, error) {
+	return _FaultDisputeGame.Contract.GameType(&_FaultDisputeGame.CallOpts)
+}
+
+// GameType is a free data retrieval call binding the contract method 0xbbdc02db.
+//
+// Solidity: function gameType() view returns(uint32 gameType_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GameType() (uint32, error) {
+	return _FaultDisputeGame.Contract.GameType(&_FaultDisputeGame.CallOpts)
+}
+
+// GetChallengerDuration is a free data retrieval call binding the contract method 0xbd8da956.
+//
+// Solidity: function getChallengerDuration(uint256 _claimIndex) view returns(uint64 duration_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GetChallengerDuration(opts *bind.CallOpts, _claimIndex *big.Int) (uint64, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "getChallengerDuration", _claimIndex)
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// GetChallengerDuration is a free data retrieval call binding the contract method 0xbd8da956.
+//
+// Solidity: function getChallengerDuration(uint256 _claimIndex) view returns(uint64 duration_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GetChallengerDuration(_claimIndex *big.Int) (uint64, error) {
+	return _FaultDisputeGame.Contract.GetChallengerDuration(&_FaultDisputeGame.CallOpts, _claimIndex)
+}
+
+// GetChallengerDuration is a free data retrieval call binding the contract method 0xbd8da956.
+//
+// Solidity: function getChallengerDuration(uint256 _claimIndex) view returns(uint64 duration_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GetChallengerDuration(_claimIndex *big.Int) (uint64, error) {
+	return _FaultDisputeGame.Contract.GetChallengerDuration(&_FaultDisputeGame.CallOpts, _claimIndex)
+}
+
+// GetNumToResolve is a free data retrieval call binding the contract method 0x5a5fa2d9.
+//
+// Solidity: function getNumToResolve(uint256 _claimIndex) view returns(uint256 numRemainingChildren_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GetNumToResolve(opts *bind.CallOpts, _claimIndex *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "getNumToResolve", _claimIndex)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNumToResolve is a free data retrieval call binding the contract method 0x5a5fa2d9.
+//
+// Solidity: function getNumToResolve(uint256 _claimIndex) view returns(uint256 numRemainingChildren_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GetNumToResolve(_claimIndex *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.GetNumToResolve(&_FaultDisputeGame.CallOpts, _claimIndex)
+}
+
+// GetNumToResolve is a free data retrieval call binding the contract method 0x5a5fa2d9.
+//
+// Solidity: function getNumToResolve(uint256 _claimIndex) view returns(uint256 numRemainingChildren_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GetNumToResolve(_claimIndex *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.GetNumToResolve(&_FaultDisputeGame.CallOpts, _claimIndex)
+}
+
+// GetRequiredBond is a free data retrieval call binding the contract method 0xc395e1ca.
+//
+// Solidity: function getRequiredBond(uint128 _position) view returns(uint256 requiredBond_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) GetRequiredBond(opts *bind.CallOpts, _position *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "getRequiredBond", _position)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetRequiredBond is a free data retrieval call binding the contract method 0xc395e1ca.
+//
+// Solidity: function getRequiredBond(uint128 _position) view returns(uint256 requiredBond_)
+func (_FaultDisputeGame *FaultDisputeGameSession) GetRequiredBond(_position *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.GetRequiredBond(&_FaultDisputeGame.CallOpts, _position)
+}
+
+// GetRequiredBond is a free data retrieval call binding the contract method 0xc395e1ca.
+//
+// Solidity: function getRequiredBond(uint128 _position) view returns(uint256 requiredBond_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) GetRequiredBond(_position *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.GetRequiredBond(&_FaultDisputeGame.CallOpts, _position)
+}
+
+// L1Head is a free data retrieval call binding the contract method 0x6361506d.
+//
+// Solidity: function l1Head() pure returns(bytes32 l1Head_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) L1Head(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "l1Head")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// L1Head is a free data retrieval call binding the contract method 0x6361506d.
+//
+// Solidity: function l1Head() pure returns(bytes32 l1Head_)
+func (_FaultDisputeGame *FaultDisputeGameSession) L1Head() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.L1Head(&_FaultDisputeGame.CallOpts)
+}
+
+// L1Head is a free data retrieval call binding the contract method 0x6361506d.
+//
+// Solidity: function l1Head() pure returns(bytes32 l1Head_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) L1Head() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.L1Head(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumber is a free data retrieval call binding the contract method 0x8b85902b.
+//
+// Solidity: function l2BlockNumber() pure returns(uint256 l2BlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) L2BlockNumber(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "l2BlockNumber")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// L2BlockNumber is a free data retrieval call binding the contract method 0x8b85902b.
+//
+// Solidity: function l2BlockNumber() pure returns(uint256 l2BlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameSession) L2BlockNumber() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumber(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumber is a free data retrieval call binding the contract method 0x8b85902b.
+//
+// Solidity: function l2BlockNumber() pure returns(uint256 l2BlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) L2BlockNumber() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumber(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumberChallenged is a free data retrieval call binding the contract method 0x3e3ac912.
+//
+// Solidity: function l2BlockNumberChallenged() view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCaller) L2BlockNumberChallenged(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "l2BlockNumberChallenged")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// L2BlockNumberChallenged is a free data retrieval call binding the contract method 0x3e3ac912.
+//
+// Solidity: function l2BlockNumberChallenged() view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameSession) L2BlockNumberChallenged() (bool, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumberChallenged(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumberChallenged is a free data retrieval call binding the contract method 0x3e3ac912.
+//
+// Solidity: function l2BlockNumberChallenged() view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) L2BlockNumberChallenged() (bool, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumberChallenged(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumberChallenger is a free data retrieval call binding the contract method 0x30dbe570.
+//
+// Solidity: function l2BlockNumberChallenger() view returns(address)
+func (_FaultDisputeGame *FaultDisputeGameCaller) L2BlockNumberChallenger(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "l2BlockNumberChallenger")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// L2BlockNumberChallenger is a free data retrieval call binding the contract method 0x30dbe570.
+//
+// Solidity: function l2BlockNumberChallenger() view returns(address)
+func (_FaultDisputeGame *FaultDisputeGameSession) L2BlockNumberChallenger() (common.Address, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumberChallenger(&_FaultDisputeGame.CallOpts)
+}
+
+// L2BlockNumberChallenger is a free data retrieval call binding the contract method 0x30dbe570.
+//
+// Solidity: function l2BlockNumberChallenger() view returns(address)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) L2BlockNumberChallenger() (common.Address, error) {
+	return _FaultDisputeGame.Contract.L2BlockNumberChallenger(&_FaultDisputeGame.CallOpts)
+}
+
+// L2ChainId is a free data retrieval call binding the contract method 0xd6ae3cd5.
+//
+// Solidity: function l2ChainId() view returns(uint256 l2ChainId_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) L2ChainId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "l2ChainId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// L2ChainId is a free data retrieval call binding the contract method 0xd6ae3cd5.
+//
+// Solidity: function l2ChainId() view returns(uint256 l2ChainId_)
+func (_FaultDisputeGame *FaultDisputeGameSession) L2ChainId() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.L2ChainId(&_FaultDisputeGame.CallOpts)
+}
+
+// L2ChainId is a free data retrieval call binding the contract method 0xd6ae3cd5.
+//
+// Solidity: function l2ChainId() view returns(uint256 l2ChainId_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) L2ChainId() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.L2ChainId(&_FaultDisputeGame.CallOpts)
+}
+
+// MaxClockDuration is a free data retrieval call binding the contract method 0xdabd396d.
+//
+// Solidity: function maxClockDuration() view returns(uint64 maxClockDuration_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) MaxClockDuration(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "maxClockDuration")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// MaxClockDuration is a free data retrieval call binding the contract method 0xdabd396d.
+//
+// Solidity: function maxClockDuration() view returns(uint64 maxClockDuration_)
+func (_FaultDisputeGame *FaultDisputeGameSession) MaxClockDuration() (uint64, error) {
+	return _FaultDisputeGame.Contract.MaxClockDuration(&_FaultDisputeGame.CallOpts)
+}
+
+// MaxClockDuration is a free data retrieval call binding the contract method 0xdabd396d.
+//
+// Solidity: function maxClockDuration() view returns(uint64 maxClockDuration_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) MaxClockDuration() (uint64, error) {
+	return _FaultDisputeGame.Contract.MaxClockDuration(&_FaultDisputeGame.CallOpts)
+}
+
+// MaxGameDepth is a free data retrieval call binding the contract method 0xfa315aa9.
+//
+// Solidity: function maxGameDepth() view returns(uint256 maxGameDepth_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) MaxGameDepth(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "maxGameDepth")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxGameDepth is a free data retrieval call binding the contract method 0xfa315aa9.
+//
+// Solidity: function maxGameDepth() view returns(uint256 maxGameDepth_)
+func (_FaultDisputeGame *FaultDisputeGameSession) MaxGameDepth() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.MaxGameDepth(&_FaultDisputeGame.CallOpts)
+}
+
+// MaxGameDepth is a free data retrieval call binding the contract method 0xfa315aa9.
+//
+// Solidity: function maxGameDepth() view returns(uint256 maxGameDepth_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) MaxGameDepth() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.MaxGameDepth(&_FaultDisputeGame.CallOpts)
+}
+
+// ResolutionCheckpoints is a free data retrieval call binding the contract method 0xa445ece6.
+//
+// Solidity: function resolutionCheckpoints(uint256 ) view returns(bool initialCheckpointComplete, uint32 subgameIndex, uint128 leftmostPosition, address counteredBy)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ResolutionCheckpoints(opts *bind.CallOpts, arg0 *big.Int) (struct {
+	InitialCheckpointComplete bool
+	SubgameIndex              uint32
+	LeftmostPosition          *big.Int
+	CounteredBy               common.Address
+}, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "resolutionCheckpoints", arg0)
+
+	outstruct := new(struct {
+		InitialCheckpointComplete bool
+		SubgameIndex              uint32
+		LeftmostPosition          *big.Int
+		CounteredBy               common.Address
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.InitialCheckpointComplete = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.SubgameIndex = *abi.ConvertType(out[1], new(uint32)).(*uint32)
+	outstruct.LeftmostPosition = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.CounteredBy = *abi.ConvertType(out[3], new(common.Address)).(*common.Address)
+
+	return *outstruct, err
+
+}
+
+// ResolutionCheckpoints is a free data retrieval call binding the contract method 0xa445ece6.
+//
+// Solidity: function resolutionCheckpoints(uint256 ) view returns(bool initialCheckpointComplete, uint32 subgameIndex, uint128 leftmostPosition, address counteredBy)
+func (_FaultDisputeGame *FaultDisputeGameSession) ResolutionCheckpoints(arg0 *big.Int) (struct {
+	InitialCheckpointComplete bool
+	SubgameIndex              uint32
+	LeftmostPosition          *big.Int
+	CounteredBy               common.Address
+}, error) {
+	return _FaultDisputeGame.Contract.ResolutionCheckpoints(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ResolutionCheckpoints is a free data retrieval call binding the contract method 0xa445ece6.
+//
+// Solidity: function resolutionCheckpoints(uint256 ) view returns(bool initialCheckpointComplete, uint32 subgameIndex, uint128 leftmostPosition, address counteredBy)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ResolutionCheckpoints(arg0 *big.Int) (struct {
+	InitialCheckpointComplete bool
+	SubgameIndex              uint32
+	LeftmostPosition          *big.Int
+	CounteredBy               common.Address
+}, error) {
+	return _FaultDisputeGame.Contract.ResolutionCheckpoints(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ResolvedAt is a free data retrieval call binding the contract method 0x19effeb4.
+//
+// Solidity: function resolvedAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ResolvedAt(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "resolvedAt")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// ResolvedAt is a free data retrieval call binding the contract method 0x19effeb4.
+//
+// Solidity: function resolvedAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameSession) ResolvedAt() (uint64, error) {
+	return _FaultDisputeGame.Contract.ResolvedAt(&_FaultDisputeGame.CallOpts)
+}
+
+// ResolvedAt is a free data retrieval call binding the contract method 0x19effeb4.
+//
+// Solidity: function resolvedAt() view returns(uint64)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ResolvedAt() (uint64, error) {
+	return _FaultDisputeGame.Contract.ResolvedAt(&_FaultDisputeGame.CallOpts)
+}
+
+// ResolvedSubgames is a free data retrieval call binding the contract method 0xfe2bbeb2.
+//
+// Solidity: function resolvedSubgames(uint256 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCaller) ResolvedSubgames(opts *bind.CallOpts, arg0 *big.Int) (bool, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "resolvedSubgames", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ResolvedSubgames is a free data retrieval call binding the contract method 0xfe2bbeb2.
+//
+// Solidity: function resolvedSubgames(uint256 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameSession) ResolvedSubgames(arg0 *big.Int) (bool, error) {
+	return _FaultDisputeGame.Contract.ResolvedSubgames(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// ResolvedSubgames is a free data retrieval call binding the contract method 0xfe2bbeb2.
+//
+// Solidity: function resolvedSubgames(uint256 ) view returns(bool)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) ResolvedSubgames(arg0 *big.Int) (bool, error) {
+	return _FaultDisputeGame.Contract.ResolvedSubgames(&_FaultDisputeGame.CallOpts, arg0)
+}
+
+// RootClaim is a free data retrieval call binding the contract method 0xbcef3b55.
+//
+// Solidity: function rootClaim() pure returns(bytes32 rootClaim_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) RootClaim(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "rootClaim")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RootClaim is a free data retrieval call binding the contract method 0xbcef3b55.
+//
+// Solidity: function rootClaim() pure returns(bytes32 rootClaim_)
+func (_FaultDisputeGame *FaultDisputeGameSession) RootClaim() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.RootClaim(&_FaultDisputeGame.CallOpts)
+}
+
+// RootClaim is a free data retrieval call binding the contract method 0xbcef3b55.
+//
+// Solidity: function rootClaim() pure returns(bytes32 rootClaim_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) RootClaim() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.RootClaim(&_FaultDisputeGame.CallOpts)
+}
+
+// SplitDepth is a free data retrieval call binding the contract method 0xec5e6308.
+//
+// Solidity: function splitDepth() view returns(uint256 splitDepth_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) SplitDepth(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "splitDepth")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SplitDepth is a free data retrieval call binding the contract method 0xec5e6308.
+//
+// Solidity: function splitDepth() view returns(uint256 splitDepth_)
+func (_FaultDisputeGame *FaultDisputeGameSession) SplitDepth() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.SplitDepth(&_FaultDisputeGame.CallOpts)
+}
+
+// SplitDepth is a free data retrieval call binding the contract method 0xec5e6308.
+//
+// Solidity: function splitDepth() view returns(uint256 splitDepth_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) SplitDepth() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.SplitDepth(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingBlockNumber is a free data retrieval call binding the contract method 0x70872aa5.
+//
+// Solidity: function startingBlockNumber() view returns(uint256 startingBlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) StartingBlockNumber(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "startingBlockNumber")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StartingBlockNumber is a free data retrieval call binding the contract method 0x70872aa5.
+//
+// Solidity: function startingBlockNumber() view returns(uint256 startingBlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameSession) StartingBlockNumber() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.StartingBlockNumber(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingBlockNumber is a free data retrieval call binding the contract method 0x70872aa5.
+//
+// Solidity: function startingBlockNumber() view returns(uint256 startingBlockNumber_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) StartingBlockNumber() (*big.Int, error) {
+	return _FaultDisputeGame.Contract.StartingBlockNumber(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingOutputRoot is a free data retrieval call binding the contract method 0x57da950e.
+//
+// Solidity: function startingOutputRoot() view returns(bytes32 root, uint256 l2BlockNumber)
+func (_FaultDisputeGame *FaultDisputeGameCaller) StartingOutputRoot(opts *bind.CallOpts) (struct {
+	Root          [32]byte
+	L2BlockNumber *big.Int
+}, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "startingOutputRoot")
+
+	outstruct := new(struct {
+		Root          [32]byte
+		L2BlockNumber *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Root = *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+	outstruct.L2BlockNumber = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// StartingOutputRoot is a free data retrieval call binding the contract method 0x57da950e.
+//
+// Solidity: function startingOutputRoot() view returns(bytes32 root, uint256 l2BlockNumber)
+func (_FaultDisputeGame *FaultDisputeGameSession) StartingOutputRoot() (struct {
+	Root          [32]byte
+	L2BlockNumber *big.Int
+}, error) {
+	return _FaultDisputeGame.Contract.StartingOutputRoot(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingOutputRoot is a free data retrieval call binding the contract method 0x57da950e.
+//
+// Solidity: function startingOutputRoot() view returns(bytes32 root, uint256 l2BlockNumber)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) StartingOutputRoot() (struct {
+	Root          [32]byte
+	L2BlockNumber *big.Int
+}, error) {
+	return _FaultDisputeGame.Contract.StartingOutputRoot(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingRootHash is a free data retrieval call binding the contract method 0x25fc2ace.
+//
+// Solidity: function startingRootHash() view returns(bytes32 startingRootHash_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) StartingRootHash(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "startingRootHash")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// StartingRootHash is a free data retrieval call binding the contract method 0x25fc2ace.
+//
+// Solidity: function startingRootHash() view returns(bytes32 startingRootHash_)
+func (_FaultDisputeGame *FaultDisputeGameSession) StartingRootHash() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.StartingRootHash(&_FaultDisputeGame.CallOpts)
+}
+
+// StartingRootHash is a free data retrieval call binding the contract method 0x25fc2ace.
+//
+// Solidity: function startingRootHash() view returns(bytes32 startingRootHash_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) StartingRootHash() ([32]byte, error) {
+	return _FaultDisputeGame.Contract.StartingRootHash(&_FaultDisputeGame.CallOpts)
+}
+
+// Status is a free data retrieval call binding the contract method 0x200d2ed2.
+//
+// Solidity: function status() view returns(uint8)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Status(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "status")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Status is a free data retrieval call binding the contract method 0x200d2ed2.
+//
+// Solidity: function status() view returns(uint8)
+func (_FaultDisputeGame *FaultDisputeGameSession) Status() (uint8, error) {
+	return _FaultDisputeGame.Contract.Status(&_FaultDisputeGame.CallOpts)
+}
+
+// Status is a free data retrieval call binding the contract method 0x200d2ed2.
+//
+// Solidity: function status() view returns(uint8)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Status() (uint8, error) {
+	return _FaultDisputeGame.Contract.Status(&_FaultDisputeGame.CallOpts)
+}
+
+// Subgames is a free data retrieval call binding the contract method 0x2ad69aeb.
+//
+// Solidity: function subgames(uint256 , uint256 ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Subgames(opts *bind.CallOpts, arg0 *big.Int, arg1 *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "subgames", arg0, arg1)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Subgames is a free data retrieval call binding the contract method 0x2ad69aeb.
+//
+// Solidity: function subgames(uint256 , uint256 ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameSession) Subgames(arg0 *big.Int, arg1 *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.Subgames(&_FaultDisputeGame.CallOpts, arg0, arg1)
+}
+
+// Subgames is a free data retrieval call binding the contract method 0x2ad69aeb.
+//
+// Solidity: function subgames(uint256 , uint256 ) view returns(uint256)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Subgames(arg0 *big.Int, arg1 *big.Int) (*big.Int, error) {
+	return _FaultDisputeGame.Contract.Subgames(&_FaultDisputeGame.CallOpts, arg0, arg1)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_FaultDisputeGame *FaultDisputeGameSession) Version() (string, error) {
+	return _FaultDisputeGame.Contract.Version(&_FaultDisputeGame.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() view returns(string)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Version() (string, error) {
+	return _FaultDisputeGame.Contract.Version(&_FaultDisputeGame.CallOpts)
+}
+
+// Vm is a free data retrieval call binding the contract method 0x3a768463.
+//
+// Solidity: function vm() view returns(address vm_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Vm(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "vm")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Vm is a free data retrieval call binding the contract method 0x3a768463.
+//
+// Solidity: function vm() view returns(address vm_)
+func (_FaultDisputeGame *FaultDisputeGameSession) Vm() (common.Address, error) {
+	return _FaultDisputeGame.Contract.Vm(&_FaultDisputeGame.CallOpts)
+}
+
+// Vm is a free data retrieval call binding the contract method 0x3a768463.
+//
+// Solidity: function vm() view returns(address vm_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Vm() (common.Address, error) {
+	return _FaultDisputeGame.Contract.Vm(&_FaultDisputeGame.CallOpts)
+}
+
+// Weth is a free data retrieval call binding the contract method 0x3fc8cef3.
+//
+// Solidity: function weth() view returns(address weth_)
+func (_FaultDisputeGame *FaultDisputeGameCaller) Weth(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FaultDisputeGame.contract.Call(opts, &out, "weth")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Weth is a free data retrieval call binding the contract method 0x3fc8cef3.
+//
+// Solidity: function weth() view returns(address weth_)
+func (_FaultDisputeGame *FaultDisputeGameSession) Weth() (common.Address, error) {
+	return _FaultDisputeGame.Contract.Weth(&_FaultDisputeGame.CallOpts)
+}
+
+// Weth is a free data retrieval call binding the contract method 0x3fc8cef3.
+//
+// Solidity: function weth() view returns(address weth_)
+func (_FaultDisputeGame *FaultDisputeGameCallerSession) Weth() (common.Address, error) {
+	return _FaultDisputeGame.Contract.Weth(&_FaultDisputeGame.CallOpts)
+}
+
+// AddLocalData is a paid mutator transaction binding the contract method 0xf8f43ff6.
+//
+// Solidity: function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) AddLocalData(opts *bind.TransactOpts, _ident *big.Int, _execLeafIdx *big.Int, _partOffset *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "addLocalData", _ident, _execLeafIdx, _partOffset)
+}
+
+// AddLocalData is a paid mutator transaction binding the contract method 0xf8f43ff6.
+//
+// Solidity: function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) AddLocalData(_ident *big.Int, _execLeafIdx *big.Int, _partOffset *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.AddLocalData(&_FaultDisputeGame.TransactOpts, _ident, _execLeafIdx, _partOffset)
+}
+
+// AddLocalData is a paid mutator transaction binding the contract method 0xf8f43ff6.
+//
+// Solidity: function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) AddLocalData(_ident *big.Int, _execLeafIdx *big.Int, _partOffset *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.AddLocalData(&_FaultDisputeGame.TransactOpts, _ident, _execLeafIdx, _partOffset)
+}
+
+// Attack is a paid mutator transaction binding the contract method 0x472777c6.
+//
+// Solidity: function attack(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Attack(opts *bind.TransactOpts, _disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "attack", _disputed, _parentIndex, _claim)
+}
+
+// Attack is a paid mutator transaction binding the contract method 0x472777c6.
+//
+// Solidity: function attack(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) Attack(_disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Attack(&_FaultDisputeGame.TransactOpts, _disputed, _parentIndex, _claim)
+}
+
+// Attack is a paid mutator transaction binding the contract method 0x472777c6.
+//
+// Solidity: function attack(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Attack(_disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Attack(&_FaultDisputeGame.TransactOpts, _disputed, _parentIndex, _claim)
+}
+
+// ChallengeRootL2Block is a paid mutator transaction binding the contract method 0x01935130.
+//
+// Solidity: function challengeRootL2Block((bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes _headerRLP) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) ChallengeRootL2Block(opts *bind.TransactOpts, _outputRootProof TypesOutputRootProof, _headerRLP []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "challengeRootL2Block", _outputRootProof, _headerRLP)
+}
+
+// ChallengeRootL2Block is a paid mutator transaction binding the contract method 0x01935130.
+//
+// Solidity: function challengeRootL2Block((bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes _headerRLP) returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) ChallengeRootL2Block(_outputRootProof TypesOutputRootProof, _headerRLP []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ChallengeRootL2Block(&_FaultDisputeGame.TransactOpts, _outputRootProof, _headerRLP)
+}
+
+// ChallengeRootL2Block is a paid mutator transaction binding the contract method 0x01935130.
+//
+// Solidity: function challengeRootL2Block((bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes _headerRLP) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) ChallengeRootL2Block(_outputRootProof TypesOutputRootProof, _headerRLP []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ChallengeRootL2Block(&_FaultDisputeGame.TransactOpts, _outputRootProof, _headerRLP)
+}
+
+// ClaimCredit is a paid mutator transaction binding the contract method 0x60e27464.
+//
+// Solidity: function claimCredit(address _recipient) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) ClaimCredit(opts *bind.TransactOpts, _recipient common.Address) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "claimCredit", _recipient)
+}
+
+// ClaimCredit is a paid mutator transaction binding the contract method 0x60e27464.
+//
+// Solidity: function claimCredit(address _recipient) returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) ClaimCredit(_recipient common.Address) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ClaimCredit(&_FaultDisputeGame.TransactOpts, _recipient)
+}
+
+// ClaimCredit is a paid mutator transaction binding the contract method 0x60e27464.
+//
+// Solidity: function claimCredit(address _recipient) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) ClaimCredit(_recipient common.Address) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ClaimCredit(&_FaultDisputeGame.TransactOpts, _recipient)
+}
+
+// Defend is a paid mutator transaction binding the contract method 0x7b0f0adc.
+//
+// Solidity: function defend(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Defend(opts *bind.TransactOpts, _disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "defend", _disputed, _parentIndex, _claim)
+}
+
+// Defend is a paid mutator transaction binding the contract method 0x7b0f0adc.
+//
+// Solidity: function defend(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) Defend(_disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Defend(&_FaultDisputeGame.TransactOpts, _disputed, _parentIndex, _claim)
+}
+
+// Defend is a paid mutator transaction binding the contract method 0x7b0f0adc.
+//
+// Solidity: function defend(bytes32 _disputed, uint256 _parentIndex, bytes32 _claim) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Defend(_disputed [32]byte, _parentIndex *big.Int, _claim [32]byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Defend(&_FaultDisputeGame.TransactOpts, _disputed, _parentIndex, _claim)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Initialize(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "initialize")
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() payable returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) Initialize() (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Initialize(&_FaultDisputeGame.TransactOpts)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Initialize() (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Initialize(&_FaultDisputeGame.TransactOpts)
+}
+
+// Move is a paid mutator transaction binding the contract method 0x6f034409.
+//
+// Solidity: function move(bytes32 _disputed, uint256 _challengeIndex, bytes32 _claim, bool _isAttack) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Move(opts *bind.TransactOpts, _disputed [32]byte, _challengeIndex *big.Int, _claim [32]byte, _isAttack bool) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "move", _disputed, _challengeIndex, _claim, _isAttack)
+}
+
+// Move is a paid mutator transaction binding the contract method 0x6f034409.
+//
+// Solidity: function move(bytes32 _disputed, uint256 _challengeIndex, bytes32 _claim, bool _isAttack) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) Move(_disputed [32]byte, _challengeIndex *big.Int, _claim [32]byte, _isAttack bool) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Move(&_FaultDisputeGame.TransactOpts, _disputed, _challengeIndex, _claim, _isAttack)
+}
+
+// Move is a paid mutator transaction binding the contract method 0x6f034409.
+//
+// Solidity: function move(bytes32 _disputed, uint256 _challengeIndex, bytes32 _claim, bool _isAttack) payable returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Move(_disputed [32]byte, _challengeIndex *big.Int, _claim [32]byte, _isAttack bool) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Move(&_FaultDisputeGame.TransactOpts, _disputed, _challengeIndex, _claim, _isAttack)
+}
+
+// Resolve is a paid mutator transaction binding the contract method 0x2810e1d6.
+//
+// Solidity: function resolve() returns(uint8 status_)
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Resolve(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "resolve")
+}
+
+// Resolve is a paid mutator transaction binding the contract method 0x2810e1d6.
+//
+// Solidity: function resolve() returns(uint8 status_)
+func (_FaultDisputeGame *FaultDisputeGameSession) Resolve() (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Resolve(&_FaultDisputeGame.TransactOpts)
+}
+
+// Resolve is a paid mutator transaction binding the contract method 0x2810e1d6.
+//
+// Solidity: function resolve() returns(uint8 status_)
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Resolve() (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Resolve(&_FaultDisputeGame.TransactOpts)
+}
+
+// ResolveClaim is a paid mutator transaction binding the contract method 0x03c2924d.
+//
+// Solidity: function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) ResolveClaim(opts *bind.TransactOpts, _claimIndex *big.Int, _numToResolve *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "resolveClaim", _claimIndex, _numToResolve)
+}
+
+// ResolveClaim is a paid mutator transaction binding the contract method 0x03c2924d.
+//
+// Solidity: function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) ResolveClaim(_claimIndex *big.Int, _numToResolve *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ResolveClaim(&_FaultDisputeGame.TransactOpts, _claimIndex, _numToResolve)
+}
+
+// ResolveClaim is a paid mutator transaction binding the contract method 0x03c2924d.
+//
+// Solidity: function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) ResolveClaim(_claimIndex *big.Int, _numToResolve *big.Int) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.ResolveClaim(&_FaultDisputeGame.TransactOpts, _claimIndex, _numToResolve)
+}
+
+// Step is a paid mutator transaction binding the contract method 0xd8cc1a3c.
+//
+// Solidity: function step(uint256 _claimIndex, bool _isAttack, bytes _stateData, bytes _proof) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactor) Step(opts *bind.TransactOpts, _claimIndex *big.Int, _isAttack bool, _stateData []byte, _proof []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.contract.Transact(opts, "step", _claimIndex, _isAttack, _stateData, _proof)
+}
+
+// Step is a paid mutator transaction binding the contract method 0xd8cc1a3c.
+//
+// Solidity: function step(uint256 _claimIndex, bool _isAttack, bytes _stateData, bytes _proof) returns()
+func (_FaultDisputeGame *FaultDisputeGameSession) Step(_claimIndex *big.Int, _isAttack bool, _stateData []byte, _proof []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Step(&_FaultDisputeGame.TransactOpts, _claimIndex, _isAttack, _stateData, _proof)
+}
+
+// Step is a paid mutator transaction binding the contract method 0xd8cc1a3c.
+//
+// Solidity: function step(uint256 _claimIndex, bool _isAttack, bytes _stateData, bytes _proof) returns()
+func (_FaultDisputeGame *FaultDisputeGameTransactorSession) Step(_claimIndex *big.Int, _isAttack bool, _stateData []byte, _proof []byte) (*types.Transaction, error) {
+	return _FaultDisputeGame.Contract.Step(&_FaultDisputeGame.TransactOpts, _claimIndex, _isAttack, _stateData, _proof)
+}
+
+// FaultDisputeGameMoveIterator is returned from FilterMove and is used to iterate over the raw logs and unpacked data for Move events raised by the FaultDisputeGame contract.
+type FaultDisputeGameMoveIterator struct {
+	Event *FaultDisputeGameMove // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FaultDisputeGameMoveIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FaultDisputeGameMove)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FaultDisputeGameMove)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FaultDisputeGameMoveIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FaultDisputeGameMoveIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FaultDisputeGameMove represents a Move event raised by the FaultDisputeGame contract.
+type FaultDisputeGameMove struct {
+	ParentIndex *big.Int
+	Claim       [32]byte
+	Claimant    common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterMove is a free log retrieval operation binding the contract event 0x9b3245740ec3b155098a55be84957a4da13eaf7f14a8bc6f53126c0b9350f2be.
+//
+// Solidity: event Move(uint256 indexed parentIndex, bytes32 indexed claim, address indexed claimant)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) FilterMove(opts *bind.FilterOpts, parentIndex []*big.Int, claim [][32]byte, claimant []common.Address) (*FaultDisputeGameMoveIterator, error) {
+
+	var parentIndexRule []interface{}
+	for _, parentIndexItem := range parentIndex {
+		parentIndexRule = append(parentIndexRule, parentIndexItem)
+	}
+	var claimRule []interface{}
+	for _, claimItem := range claim {
+		claimRule = append(claimRule, claimItem)
+	}
+	var claimantRule []interface{}
+	for _, claimantItem := range claimant {
+		claimantRule = append(claimantRule, claimantItem)
+	}
+
+	logs, sub, err := _FaultDisputeGame.contract.FilterLogs(opts, "Move", parentIndexRule, claimRule, claimantRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGameMoveIterator{contract: _FaultDisputeGame.contract, event: "Move", logs: logs, sub: sub}, nil
+}
+
+// WatchMove is a free log subscription operation binding the contract event 0x9b3245740ec3b155098a55be84957a4da13eaf7f14a8bc6f53126c0b9350f2be.
+//
+// Solidity: event Move(uint256 indexed parentIndex, bytes32 indexed claim, address indexed claimant)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) WatchMove(opts *bind.WatchOpts, sink chan<- *FaultDisputeGameMove, parentIndex []*big.Int, claim [][32]byte, claimant []common.Address) (event.Subscription, error) {
+
+	var parentIndexRule []interface{}
+	for _, parentIndexItem := range parentIndex {
+		parentIndexRule = append(parentIndexRule, parentIndexItem)
+	}
+	var claimRule []interface{}
+	for _, claimItem := range claim {
+		claimRule = append(claimRule, claimItem)
+	}
+	var claimantRule []interface{}
+	for _, claimantItem := range claimant {
+		claimantRule = append(claimantRule, claimantItem)
+	}
+
+	logs, sub, err := _FaultDisputeGame.contract.WatchLogs(opts, "Move", parentIndexRule, claimRule, claimantRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FaultDisputeGameMove)
+				if err := _FaultDisputeGame.contract.UnpackLog(event, "Move", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMove is a log parse operation binding the contract event 0x9b3245740ec3b155098a55be84957a4da13eaf7f14a8bc6f53126c0b9350f2be.
+//
+// Solidity: event Move(uint256 indexed parentIndex, bytes32 indexed claim, address indexed claimant)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) ParseMove(log types.Log) (*FaultDisputeGameMove, error) {
+	event := new(FaultDisputeGameMove)
+	if err := _FaultDisputeGame.contract.UnpackLog(event, "Move", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FaultDisputeGameResolvedIterator is returned from FilterResolved and is used to iterate over the raw logs and unpacked data for Resolved events raised by the FaultDisputeGame contract.
+type FaultDisputeGameResolvedIterator struct {
+	Event *FaultDisputeGameResolved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FaultDisputeGameResolvedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FaultDisputeGameResolved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FaultDisputeGameResolved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FaultDisputeGameResolvedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FaultDisputeGameResolvedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FaultDisputeGameResolved represents a Resolved event raised by the FaultDisputeGame contract.
+type FaultDisputeGameResolved struct {
+	Status uint8
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterResolved is a free log retrieval operation binding the contract event 0x5e186f09b9c93491f14e277eea7faa5de6a2d4bda75a79af7a3684fbfb42da60.
+//
+// Solidity: event Resolved(uint8 indexed status)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) FilterResolved(opts *bind.FilterOpts, status []uint8) (*FaultDisputeGameResolvedIterator, error) {
+
+	var statusRule []interface{}
+	for _, statusItem := range status {
+		statusRule = append(statusRule, statusItem)
+	}
+
+	logs, sub, err := _FaultDisputeGame.contract.FilterLogs(opts, "Resolved", statusRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FaultDisputeGameResolvedIterator{contract: _FaultDisputeGame.contract, event: "Resolved", logs: logs, sub: sub}, nil
+}
+
+// WatchResolved is a free log subscription operation binding the contract event 0x5e186f09b9c93491f14e277eea7faa5de6a2d4bda75a79af7a3684fbfb42da60.
+//
+// Solidity: event Resolved(uint8 indexed status)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) WatchResolved(opts *bind.WatchOpts, sink chan<- *FaultDisputeGameResolved, status []uint8) (event.Subscription, error) {
+
+	var statusRule []interface{}
+	for _, statusItem := range status {
+		statusRule = append(statusRule, statusItem)
+	}
+
+	logs, sub, err := _FaultDisputeGame.contract.WatchLogs(opts, "Resolved", statusRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FaultDisputeGameResolved)
+				if err := _FaultDisputeGame.contract.UnpackLog(event, "Resolved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResolved is a log parse operation binding the contract event 0x5e186f09b9c93491f14e277eea7faa5de6a2d4bda75a79af7a3684fbfb42da60.
+//
+// Solidity: event Resolved(uint8 indexed status)
+func (_FaultDisputeGame *FaultDisputeGameFilterer) ParseResolved(log types.Log) (*FaultDisputeGameResolved, error) {
+	event := new(FaultDisputeGameResolved)
+	if err := _FaultDisputeGame.contract.UnpackLog(event, "Resolved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/op-monitorism/withdrawals-v2/bindings/OptimismPortal2.go
+++ b/op-monitorism/withdrawals-v2/bindings/OptimismPortal2.go
@@ -1,0 +1,2127 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TypesWithdrawalTransaction is an auto generated low-level Go binding around an user-defined struct.
+type TypesWithdrawalTransaction struct {
+	Nonce    *big.Int
+	Sender   common.Address
+	Target   common.Address
+	Value    *big.Int
+	GasLimit *big.Int
+	Data     []byte
+}
+
+// OptimismPortal2MetaData contains all meta data concerning the OptimismPortal2 contract.
+var OptimismPortal2MetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_proofMaturityDelaySeconds\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_disputeGameFinalityDelaySeconds\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"},{\"inputs\":[],\"name\":\"balance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractIDisputeGame\",\"name\":\"_disputeGame\",\"type\":\"address\"}],\"name\":\"blacklistDisputeGame\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_withdrawalHash\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"_proofSubmitter\",\"type\":\"address\"}],\"name\":\"checkWithdrawal\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_mint\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_value\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"_gasLimit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"_isCreation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"depositERC20Transaction\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_value\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"_gasLimit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"_isCreation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"depositTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractIDisputeGame\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"disputeGameBlacklist\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"disputeGameFactory\",\"outputs\":[{\"internalType\":\"contractIDisputeGameFactory\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"disputeGameFinalityDelaySeconds\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"donateETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"internalType\":\"structTypes.WithdrawalTransaction\",\"name\":\"_tx\",\"type\":\"tuple\"}],\"name\":\"finalizeWithdrawalTransaction\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"internalType\":\"structTypes.WithdrawalTransaction\",\"name\":\"_tx\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_proofSubmitter\",\"type\":\"address\"}],\"name\":\"finalizeWithdrawalTransactionExternalProof\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"finalizedWithdrawals\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"guardian\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractIDisputeGameFactory\",\"name\":\"_disputeGameFactory\",\"type\":\"address\"},{\"internalType\":\"contractISystemConfig\",\"name\":\"_systemConfig\",\"type\":\"address\"},{\"internalType\":\"contractISuperchainConfig\",\"name\":\"_superchainConfig\",\"type\":\"address\"},{\"internalType\":\"GameType\",\"name\":\"_initialRespectedGameType\",\"type\":\"uint32\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l2Sender\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"_byteCount\",\"type\":\"uint64\"}],\"name\":\"minimumGasLimit\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_withdrawalHash\",\"type\":\"bytes32\"}],\"name\":\"numProofSubmitters\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"params\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"prevBaseFee\",\"type\":\"uint128\"},{\"internalType\":\"uint64\",\"name\":\"prevBoughtGas\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"prevBlockNum\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proofMaturityDelaySeconds\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"proofSubmitters\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"internalType\":\"structTypes.WithdrawalTransaction\",\"name\":\"_tx\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"_disputeGameIndex\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"version\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"stateRoot\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"messagePasserStorageRoot\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"latestBlockhash\",\"type\":\"bytes32\"}],\"internalType\":\"structTypes.OutputRootProof\",\"name\":\"_outputRootProof\",\"type\":\"tuple\"},{\"internalType\":\"bytes[]\",\"name\":\"_withdrawalProof\",\"type\":\"bytes[]\"}],\"name\":\"proveWithdrawalTransaction\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"provenWithdrawals\",\"outputs\":[{\"internalType\":\"contractIDisputeGame\",\"name\":\"disputeGameProxy\",\"type\":\"address\"},{\"internalType\":\"uint64\",\"name\":\"timestamp\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"respectedGameType\",\"outputs\":[{\"internalType\":\"GameType\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"respectedGameTypeUpdatedAt\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_token\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"_decimals\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"_name\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_symbol\",\"type\":\"bytes32\"}],\"name\":\"setGasPayingToken\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"GameType\",\"name\":\"_gameType\",\"type\":\"uint32\"}],\"name\":\"setRespectedGameType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"superchainConfig\",\"outputs\":[{\"internalType\":\"contractISuperchainConfig\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"systemConfig\",\"outputs\":[{\"internalType\":\"contractISystemConfig\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"contractIDisputeGame\",\"name\":\"disputeGame\",\"type\":\"address\"}],\"name\":\"DisputeGameBlacklisted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"GameType\",\"name\":\"newGameType\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"Timestamp\",\"name\":\"updatedAt\",\"type\":\"uint64\"}],\"name\":\"RespectedGameTypeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"version\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"opaqueData\",\"type\":\"bytes\"}],\"name\":\"TransactionDeposited\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"withdrawalHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"name\":\"WithdrawalFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"withdrawalHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"WithdrawalProven\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"withdrawalHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"proofSubmitter\",\"type\":\"address\"}],\"name\":\"WithdrawalProvenExtension1\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"AlreadyFinalized\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BadTarget\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"Blacklisted\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"CallPaused\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ContentLengthMismatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EmptyItem\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"GasEstimation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDataRemainder\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDisputeGame\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidGameType\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidHeader\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidMerkleProof\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidProof\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LargeCalldata\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoValue\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NonReentrant\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlyCustomGasToken\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OutOfGas\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ProposalNotValidated\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SmallGasLimit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TransferFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"Unauthorized\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnexpectedList\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnexpectedString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"Unproven\",\"type\":\"error\"}]",
+}
+
+// OptimismPortal2ABI is the input ABI used to generate the binding from.
+// Deprecated: Use OptimismPortal2MetaData.ABI instead.
+var OptimismPortal2ABI = OptimismPortal2MetaData.ABI
+
+// OptimismPortal2 is an auto generated Go binding around an Ethereum contract.
+type OptimismPortal2 struct {
+	OptimismPortal2Caller     // Read-only binding to the contract
+	OptimismPortal2Transactor // Write-only binding to the contract
+	OptimismPortal2Filterer   // Log filterer for contract events
+}
+
+// OptimismPortal2Caller is an auto generated read-only Go binding around an Ethereum contract.
+type OptimismPortal2Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OptimismPortal2Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type OptimismPortal2Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OptimismPortal2Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type OptimismPortal2Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OptimismPortal2Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type OptimismPortal2Session struct {
+	Contract     *OptimismPortal2  // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// OptimismPortal2CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type OptimismPortal2CallerSession struct {
+	Contract *OptimismPortal2Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts          // Call options to use throughout this session
+}
+
+// OptimismPortal2TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type OptimismPortal2TransactorSession struct {
+	Contract     *OptimismPortal2Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts          // Transaction auth options to use throughout this session
+}
+
+// OptimismPortal2Raw is an auto generated low-level Go binding around an Ethereum contract.
+type OptimismPortal2Raw struct {
+	Contract *OptimismPortal2 // Generic contract binding to access the raw methods on
+}
+
+// OptimismPortal2CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type OptimismPortal2CallerRaw struct {
+	Contract *OptimismPortal2Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// OptimismPortal2TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type OptimismPortal2TransactorRaw struct {
+	Contract *OptimismPortal2Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOptimismPortal2 creates a new instance of OptimismPortal2, bound to a specific deployed contract.
+func NewOptimismPortal2(address common.Address, backend bind.ContractBackend) (*OptimismPortal2, error) {
+	contract, err := bindOptimismPortal2(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2{OptimismPortal2Caller: OptimismPortal2Caller{contract: contract}, OptimismPortal2Transactor: OptimismPortal2Transactor{contract: contract}, OptimismPortal2Filterer: OptimismPortal2Filterer{contract: contract}}, nil
+}
+
+// NewOptimismPortal2Caller creates a new read-only instance of OptimismPortal2, bound to a specific deployed contract.
+func NewOptimismPortal2Caller(address common.Address, caller bind.ContractCaller) (*OptimismPortal2Caller, error) {
+	contract, err := bindOptimismPortal2(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2Caller{contract: contract}, nil
+}
+
+// NewOptimismPortal2Transactor creates a new write-only instance of OptimismPortal2, bound to a specific deployed contract.
+func NewOptimismPortal2Transactor(address common.Address, transactor bind.ContractTransactor) (*OptimismPortal2Transactor, error) {
+	contract, err := bindOptimismPortal2(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2Transactor{contract: contract}, nil
+}
+
+// NewOptimismPortal2Filterer creates a new log filterer instance of OptimismPortal2, bound to a specific deployed contract.
+func NewOptimismPortal2Filterer(address common.Address, filterer bind.ContractFilterer) (*OptimismPortal2Filterer, error) {
+	contract, err := bindOptimismPortal2(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2Filterer{contract: contract}, nil
+}
+
+// bindOptimismPortal2 binds a generic wrapper to an already deployed contract.
+func bindOptimismPortal2(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := OptimismPortal2MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OptimismPortal2 *OptimismPortal2Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OptimismPortal2.Contract.OptimismPortal2Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OptimismPortal2 *OptimismPortal2Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.OptimismPortal2Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OptimismPortal2 *OptimismPortal2Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.OptimismPortal2Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OptimismPortal2 *OptimismPortal2CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OptimismPortal2.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OptimismPortal2 *OptimismPortal2TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OptimismPortal2 *OptimismPortal2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.contract.Transact(opts, method, params...)
+}
+
+// Balance is a free data retrieval call binding the contract method 0xb69ef8a8.
+//
+// Solidity: function balance() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Caller) Balance(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "balance")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Balance is a free data retrieval call binding the contract method 0xb69ef8a8.
+//
+// Solidity: function balance() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Session) Balance() (*big.Int, error) {
+	return _OptimismPortal2.Contract.Balance(&_OptimismPortal2.CallOpts)
+}
+
+// Balance is a free data retrieval call binding the contract method 0xb69ef8a8.
+//
+// Solidity: function balance() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) Balance() (*big.Int, error) {
+	return _OptimismPortal2.Contract.Balance(&_OptimismPortal2.CallOpts)
+}
+
+// CheckWithdrawal is a free data retrieval call binding the contract method 0x71c1566e.
+//
+// Solidity: function checkWithdrawal(bytes32 _withdrawalHash, address _proofSubmitter) view returns()
+func (_OptimismPortal2 *OptimismPortal2Caller) CheckWithdrawal(opts *bind.CallOpts, _withdrawalHash [32]byte, _proofSubmitter common.Address) error {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "checkWithdrawal", _withdrawalHash, _proofSubmitter)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// CheckWithdrawal is a free data retrieval call binding the contract method 0x71c1566e.
+//
+// Solidity: function checkWithdrawal(bytes32 _withdrawalHash, address _proofSubmitter) view returns()
+func (_OptimismPortal2 *OptimismPortal2Session) CheckWithdrawal(_withdrawalHash [32]byte, _proofSubmitter common.Address) error {
+	return _OptimismPortal2.Contract.CheckWithdrawal(&_OptimismPortal2.CallOpts, _withdrawalHash, _proofSubmitter)
+}
+
+// CheckWithdrawal is a free data retrieval call binding the contract method 0x71c1566e.
+//
+// Solidity: function checkWithdrawal(bytes32 _withdrawalHash, address _proofSubmitter) view returns()
+func (_OptimismPortal2 *OptimismPortal2CallerSession) CheckWithdrawal(_withdrawalHash [32]byte, _proofSubmitter common.Address) error {
+	return _OptimismPortal2.Contract.CheckWithdrawal(&_OptimismPortal2.CallOpts, _withdrawalHash, _proofSubmitter)
+}
+
+// DisputeGameBlacklist is a free data retrieval call binding the contract method 0x45884d32.
+//
+// Solidity: function disputeGameBlacklist(address ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Caller) DisputeGameBlacklist(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "disputeGameBlacklist", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// DisputeGameBlacklist is a free data retrieval call binding the contract method 0x45884d32.
+//
+// Solidity: function disputeGameBlacklist(address ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Session) DisputeGameBlacklist(arg0 common.Address) (bool, error) {
+	return _OptimismPortal2.Contract.DisputeGameBlacklist(&_OptimismPortal2.CallOpts, arg0)
+}
+
+// DisputeGameBlacklist is a free data retrieval call binding the contract method 0x45884d32.
+//
+// Solidity: function disputeGameBlacklist(address ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) DisputeGameBlacklist(arg0 common.Address) (bool, error) {
+	return _OptimismPortal2.Contract.DisputeGameBlacklist(&_OptimismPortal2.CallOpts, arg0)
+}
+
+// DisputeGameFactory is a free data retrieval call binding the contract method 0xf2b4e617.
+//
+// Solidity: function disputeGameFactory() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) DisputeGameFactory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "disputeGameFactory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DisputeGameFactory is a free data retrieval call binding the contract method 0xf2b4e617.
+//
+// Solidity: function disputeGameFactory() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) DisputeGameFactory() (common.Address, error) {
+	return _OptimismPortal2.Contract.DisputeGameFactory(&_OptimismPortal2.CallOpts)
+}
+
+// DisputeGameFactory is a free data retrieval call binding the contract method 0xf2b4e617.
+//
+// Solidity: function disputeGameFactory() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) DisputeGameFactory() (common.Address, error) {
+	return _OptimismPortal2.Contract.DisputeGameFactory(&_OptimismPortal2.CallOpts)
+}
+
+// DisputeGameFinalityDelaySeconds is a free data retrieval call binding the contract method 0x952b2797.
+//
+// Solidity: function disputeGameFinalityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Caller) DisputeGameFinalityDelaySeconds(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "disputeGameFinalityDelaySeconds")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DisputeGameFinalityDelaySeconds is a free data retrieval call binding the contract method 0x952b2797.
+//
+// Solidity: function disputeGameFinalityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Session) DisputeGameFinalityDelaySeconds() (*big.Int, error) {
+	return _OptimismPortal2.Contract.DisputeGameFinalityDelaySeconds(&_OptimismPortal2.CallOpts)
+}
+
+// DisputeGameFinalityDelaySeconds is a free data retrieval call binding the contract method 0x952b2797.
+//
+// Solidity: function disputeGameFinalityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) DisputeGameFinalityDelaySeconds() (*big.Int, error) {
+	return _OptimismPortal2.Contract.DisputeGameFinalityDelaySeconds(&_OptimismPortal2.CallOpts)
+}
+
+// FinalizedWithdrawals is a free data retrieval call binding the contract method 0xa14238e7.
+//
+// Solidity: function finalizedWithdrawals(bytes32 ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Caller) FinalizedWithdrawals(opts *bind.CallOpts, arg0 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "finalizedWithdrawals", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// FinalizedWithdrawals is a free data retrieval call binding the contract method 0xa14238e7.
+//
+// Solidity: function finalizedWithdrawals(bytes32 ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Session) FinalizedWithdrawals(arg0 [32]byte) (bool, error) {
+	return _OptimismPortal2.Contract.FinalizedWithdrawals(&_OptimismPortal2.CallOpts, arg0)
+}
+
+// FinalizedWithdrawals is a free data retrieval call binding the contract method 0xa14238e7.
+//
+// Solidity: function finalizedWithdrawals(bytes32 ) view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) FinalizedWithdrawals(arg0 [32]byte) (bool, error) {
+	return _OptimismPortal2.Contract.FinalizedWithdrawals(&_OptimismPortal2.CallOpts, arg0)
+}
+
+// Guardian is a free data retrieval call binding the contract method 0x452a9320.
+//
+// Solidity: function guardian() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) Guardian(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "guardian")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Guardian is a free data retrieval call binding the contract method 0x452a9320.
+//
+// Solidity: function guardian() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) Guardian() (common.Address, error) {
+	return _OptimismPortal2.Contract.Guardian(&_OptimismPortal2.CallOpts)
+}
+
+// Guardian is a free data retrieval call binding the contract method 0x452a9320.
+//
+// Solidity: function guardian() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) Guardian() (common.Address, error) {
+	return _OptimismPortal2.Contract.Guardian(&_OptimismPortal2.CallOpts)
+}
+
+// L2Sender is a free data retrieval call binding the contract method 0x9bf62d82.
+//
+// Solidity: function l2Sender() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) L2Sender(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "l2Sender")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// L2Sender is a free data retrieval call binding the contract method 0x9bf62d82.
+//
+// Solidity: function l2Sender() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) L2Sender() (common.Address, error) {
+	return _OptimismPortal2.Contract.L2Sender(&_OptimismPortal2.CallOpts)
+}
+
+// L2Sender is a free data retrieval call binding the contract method 0x9bf62d82.
+//
+// Solidity: function l2Sender() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) L2Sender() (common.Address, error) {
+	return _OptimismPortal2.Contract.L2Sender(&_OptimismPortal2.CallOpts)
+}
+
+// MinimumGasLimit is a free data retrieval call binding the contract method 0xa35d99df.
+//
+// Solidity: function minimumGasLimit(uint64 _byteCount) pure returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2Caller) MinimumGasLimit(opts *bind.CallOpts, _byteCount uint64) (uint64, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "minimumGasLimit", _byteCount)
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// MinimumGasLimit is a free data retrieval call binding the contract method 0xa35d99df.
+//
+// Solidity: function minimumGasLimit(uint64 _byteCount) pure returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2Session) MinimumGasLimit(_byteCount uint64) (uint64, error) {
+	return _OptimismPortal2.Contract.MinimumGasLimit(&_OptimismPortal2.CallOpts, _byteCount)
+}
+
+// MinimumGasLimit is a free data retrieval call binding the contract method 0xa35d99df.
+//
+// Solidity: function minimumGasLimit(uint64 _byteCount) pure returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) MinimumGasLimit(_byteCount uint64) (uint64, error) {
+	return _OptimismPortal2.Contract.MinimumGasLimit(&_OptimismPortal2.CallOpts, _byteCount)
+}
+
+// NumProofSubmitters is a free data retrieval call binding the contract method 0x513747ab.
+//
+// Solidity: function numProofSubmitters(bytes32 _withdrawalHash) view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Caller) NumProofSubmitters(opts *bind.CallOpts, _withdrawalHash [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "numProofSubmitters", _withdrawalHash)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NumProofSubmitters is a free data retrieval call binding the contract method 0x513747ab.
+//
+// Solidity: function numProofSubmitters(bytes32 _withdrawalHash) view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Session) NumProofSubmitters(_withdrawalHash [32]byte) (*big.Int, error) {
+	return _OptimismPortal2.Contract.NumProofSubmitters(&_OptimismPortal2.CallOpts, _withdrawalHash)
+}
+
+// NumProofSubmitters is a free data retrieval call binding the contract method 0x513747ab.
+//
+// Solidity: function numProofSubmitters(bytes32 _withdrawalHash) view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) NumProofSubmitters(_withdrawalHash [32]byte) (*big.Int, error) {
+	return _OptimismPortal2.Contract.NumProofSubmitters(&_OptimismPortal2.CallOpts, _withdrawalHash)
+}
+
+// Params is a free data retrieval call binding the contract method 0xcff0ab96.
+//
+// Solidity: function params() view returns(uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum)
+func (_OptimismPortal2 *OptimismPortal2Caller) Params(opts *bind.CallOpts) (struct {
+	PrevBaseFee   *big.Int
+	PrevBoughtGas uint64
+	PrevBlockNum  uint64
+}, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "params")
+
+	outstruct := new(struct {
+		PrevBaseFee   *big.Int
+		PrevBoughtGas uint64
+		PrevBlockNum  uint64
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.PrevBaseFee = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.PrevBoughtGas = *abi.ConvertType(out[1], new(uint64)).(*uint64)
+	outstruct.PrevBlockNum = *abi.ConvertType(out[2], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+// Params is a free data retrieval call binding the contract method 0xcff0ab96.
+//
+// Solidity: function params() view returns(uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum)
+func (_OptimismPortal2 *OptimismPortal2Session) Params() (struct {
+	PrevBaseFee   *big.Int
+	PrevBoughtGas uint64
+	PrevBlockNum  uint64
+}, error) {
+	return _OptimismPortal2.Contract.Params(&_OptimismPortal2.CallOpts)
+}
+
+// Params is a free data retrieval call binding the contract method 0xcff0ab96.
+//
+// Solidity: function params() view returns(uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) Params() (struct {
+	PrevBaseFee   *big.Int
+	PrevBoughtGas uint64
+	PrevBlockNum  uint64
+}, error) {
+	return _OptimismPortal2.Contract.Params(&_OptimismPortal2.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Caller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2Session) Paused() (bool, error) {
+	return _OptimismPortal2.Contract.Paused(&_OptimismPortal2.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) Paused() (bool, error) {
+	return _OptimismPortal2.Contract.Paused(&_OptimismPortal2.CallOpts)
+}
+
+// ProofMaturityDelaySeconds is a free data retrieval call binding the contract method 0xbf653a5c.
+//
+// Solidity: function proofMaturityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Caller) ProofMaturityDelaySeconds(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "proofMaturityDelaySeconds")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ProofMaturityDelaySeconds is a free data retrieval call binding the contract method 0xbf653a5c.
+//
+// Solidity: function proofMaturityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2Session) ProofMaturityDelaySeconds() (*big.Int, error) {
+	return _OptimismPortal2.Contract.ProofMaturityDelaySeconds(&_OptimismPortal2.CallOpts)
+}
+
+// ProofMaturityDelaySeconds is a free data retrieval call binding the contract method 0xbf653a5c.
+//
+// Solidity: function proofMaturityDelaySeconds() view returns(uint256)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) ProofMaturityDelaySeconds() (*big.Int, error) {
+	return _OptimismPortal2.Contract.ProofMaturityDelaySeconds(&_OptimismPortal2.CallOpts)
+}
+
+// ProofSubmitters is a free data retrieval call binding the contract method 0xa3860f48.
+//
+// Solidity: function proofSubmitters(bytes32 , uint256 ) view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) ProofSubmitters(opts *bind.CallOpts, arg0 [32]byte, arg1 *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "proofSubmitters", arg0, arg1)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ProofSubmitters is a free data retrieval call binding the contract method 0xa3860f48.
+//
+// Solidity: function proofSubmitters(bytes32 , uint256 ) view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) ProofSubmitters(arg0 [32]byte, arg1 *big.Int) (common.Address, error) {
+	return _OptimismPortal2.Contract.ProofSubmitters(&_OptimismPortal2.CallOpts, arg0, arg1)
+}
+
+// ProofSubmitters is a free data retrieval call binding the contract method 0xa3860f48.
+//
+// Solidity: function proofSubmitters(bytes32 , uint256 ) view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) ProofSubmitters(arg0 [32]byte, arg1 *big.Int) (common.Address, error) {
+	return _OptimismPortal2.Contract.ProofSubmitters(&_OptimismPortal2.CallOpts, arg0, arg1)
+}
+
+// ProvenWithdrawals is a free data retrieval call binding the contract method 0xbb2c727e.
+//
+// Solidity: function provenWithdrawals(bytes32 , address ) view returns(address disputeGameProxy, uint64 timestamp)
+func (_OptimismPortal2 *OptimismPortal2Caller) ProvenWithdrawals(opts *bind.CallOpts, arg0 [32]byte, arg1 common.Address) (struct {
+	DisputeGameProxy common.Address
+	Timestamp        uint64
+}, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "provenWithdrawals", arg0, arg1)
+
+	outstruct := new(struct {
+		DisputeGameProxy common.Address
+		Timestamp        uint64
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.DisputeGameProxy = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.Timestamp = *abi.ConvertType(out[1], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+// ProvenWithdrawals is a free data retrieval call binding the contract method 0xbb2c727e.
+//
+// Solidity: function provenWithdrawals(bytes32 , address ) view returns(address disputeGameProxy, uint64 timestamp)
+func (_OptimismPortal2 *OptimismPortal2Session) ProvenWithdrawals(arg0 [32]byte, arg1 common.Address) (struct {
+	DisputeGameProxy common.Address
+	Timestamp        uint64
+}, error) {
+	return _OptimismPortal2.Contract.ProvenWithdrawals(&_OptimismPortal2.CallOpts, arg0, arg1)
+}
+
+// ProvenWithdrawals is a free data retrieval call binding the contract method 0xbb2c727e.
+//
+// Solidity: function provenWithdrawals(bytes32 , address ) view returns(address disputeGameProxy, uint64 timestamp)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) ProvenWithdrawals(arg0 [32]byte, arg1 common.Address) (struct {
+	DisputeGameProxy common.Address
+	Timestamp        uint64
+}, error) {
+	return _OptimismPortal2.Contract.ProvenWithdrawals(&_OptimismPortal2.CallOpts, arg0, arg1)
+}
+
+// RespectedGameType is a free data retrieval call binding the contract method 0x3c9f397c.
+//
+// Solidity: function respectedGameType() view returns(uint32)
+func (_OptimismPortal2 *OptimismPortal2Caller) RespectedGameType(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "respectedGameType")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// RespectedGameType is a free data retrieval call binding the contract method 0x3c9f397c.
+//
+// Solidity: function respectedGameType() view returns(uint32)
+func (_OptimismPortal2 *OptimismPortal2Session) RespectedGameType() (uint32, error) {
+	return _OptimismPortal2.Contract.RespectedGameType(&_OptimismPortal2.CallOpts)
+}
+
+// RespectedGameType is a free data retrieval call binding the contract method 0x3c9f397c.
+//
+// Solidity: function respectedGameType() view returns(uint32)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) RespectedGameType() (uint32, error) {
+	return _OptimismPortal2.Contract.RespectedGameType(&_OptimismPortal2.CallOpts)
+}
+
+// RespectedGameTypeUpdatedAt is a free data retrieval call binding the contract method 0x4fd0434c.
+//
+// Solidity: function respectedGameTypeUpdatedAt() view returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2Caller) RespectedGameTypeUpdatedAt(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "respectedGameTypeUpdatedAt")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// RespectedGameTypeUpdatedAt is a free data retrieval call binding the contract method 0x4fd0434c.
+//
+// Solidity: function respectedGameTypeUpdatedAt() view returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2Session) RespectedGameTypeUpdatedAt() (uint64, error) {
+	return _OptimismPortal2.Contract.RespectedGameTypeUpdatedAt(&_OptimismPortal2.CallOpts)
+}
+
+// RespectedGameTypeUpdatedAt is a free data retrieval call binding the contract method 0x4fd0434c.
+//
+// Solidity: function respectedGameTypeUpdatedAt() view returns(uint64)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) RespectedGameTypeUpdatedAt() (uint64, error) {
+	return _OptimismPortal2.Contract.RespectedGameTypeUpdatedAt(&_OptimismPortal2.CallOpts)
+}
+
+// SuperchainConfig is a free data retrieval call binding the contract method 0x35e80ab3.
+//
+// Solidity: function superchainConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) SuperchainConfig(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "superchainConfig")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SuperchainConfig is a free data retrieval call binding the contract method 0x35e80ab3.
+//
+// Solidity: function superchainConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) SuperchainConfig() (common.Address, error) {
+	return _OptimismPortal2.Contract.SuperchainConfig(&_OptimismPortal2.CallOpts)
+}
+
+// SuperchainConfig is a free data retrieval call binding the contract method 0x35e80ab3.
+//
+// Solidity: function superchainConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) SuperchainConfig() (common.Address, error) {
+	return _OptimismPortal2.Contract.SuperchainConfig(&_OptimismPortal2.CallOpts)
+}
+
+// SystemConfig is a free data retrieval call binding the contract method 0x33d7e2bd.
+//
+// Solidity: function systemConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Caller) SystemConfig(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "systemConfig")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SystemConfig is a free data retrieval call binding the contract method 0x33d7e2bd.
+//
+// Solidity: function systemConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2Session) SystemConfig() (common.Address, error) {
+	return _OptimismPortal2.Contract.SystemConfig(&_OptimismPortal2.CallOpts)
+}
+
+// SystemConfig is a free data retrieval call binding the contract method 0x33d7e2bd.
+//
+// Solidity: function systemConfig() view returns(address)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) SystemConfig() (common.Address, error) {
+	return _OptimismPortal2.Contract.SystemConfig(&_OptimismPortal2.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(string)
+func (_OptimismPortal2 *OptimismPortal2Caller) Version(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _OptimismPortal2.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(string)
+func (_OptimismPortal2 *OptimismPortal2Session) Version() (string, error) {
+	return _OptimismPortal2.Contract.Version(&_OptimismPortal2.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(string)
+func (_OptimismPortal2 *OptimismPortal2CallerSession) Version() (string, error) {
+	return _OptimismPortal2.Contract.Version(&_OptimismPortal2.CallOpts)
+}
+
+// BlacklistDisputeGame is a paid mutator transaction binding the contract method 0x7d6be8dc.
+//
+// Solidity: function blacklistDisputeGame(address _disputeGame) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) BlacklistDisputeGame(opts *bind.TransactOpts, _disputeGame common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "blacklistDisputeGame", _disputeGame)
+}
+
+// BlacklistDisputeGame is a paid mutator transaction binding the contract method 0x7d6be8dc.
+//
+// Solidity: function blacklistDisputeGame(address _disputeGame) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) BlacklistDisputeGame(_disputeGame common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.BlacklistDisputeGame(&_OptimismPortal2.TransactOpts, _disputeGame)
+}
+
+// BlacklistDisputeGame is a paid mutator transaction binding the contract method 0x7d6be8dc.
+//
+// Solidity: function blacklistDisputeGame(address _disputeGame) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) BlacklistDisputeGame(_disputeGame common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.BlacklistDisputeGame(&_OptimismPortal2.TransactOpts, _disputeGame)
+}
+
+// DepositERC20Transaction is a paid mutator transaction binding the contract method 0x149f2f22.
+//
+// Solidity: function depositERC20Transaction(address _to, uint256 _mint, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) DepositERC20Transaction(opts *bind.TransactOpts, _to common.Address, _mint *big.Int, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "depositERC20Transaction", _to, _mint, _value, _gasLimit, _isCreation, _data)
+}
+
+// DepositERC20Transaction is a paid mutator transaction binding the contract method 0x149f2f22.
+//
+// Solidity: function depositERC20Transaction(address _to, uint256 _mint, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) DepositERC20Transaction(_to common.Address, _mint *big.Int, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DepositERC20Transaction(&_OptimismPortal2.TransactOpts, _to, _mint, _value, _gasLimit, _isCreation, _data)
+}
+
+// DepositERC20Transaction is a paid mutator transaction binding the contract method 0x149f2f22.
+//
+// Solidity: function depositERC20Transaction(address _to, uint256 _mint, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) DepositERC20Transaction(_to common.Address, _mint *big.Int, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DepositERC20Transaction(&_OptimismPortal2.TransactOpts, _to, _mint, _value, _gasLimit, _isCreation, _data)
+}
+
+// DepositTransaction is a paid mutator transaction binding the contract method 0xe9e05c42.
+//
+// Solidity: function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) payable returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) DepositTransaction(opts *bind.TransactOpts, _to common.Address, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "depositTransaction", _to, _value, _gasLimit, _isCreation, _data)
+}
+
+// DepositTransaction is a paid mutator transaction binding the contract method 0xe9e05c42.
+//
+// Solidity: function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) payable returns()
+func (_OptimismPortal2 *OptimismPortal2Session) DepositTransaction(_to common.Address, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DepositTransaction(&_OptimismPortal2.TransactOpts, _to, _value, _gasLimit, _isCreation, _data)
+}
+
+// DepositTransaction is a paid mutator transaction binding the contract method 0xe9e05c42.
+//
+// Solidity: function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes _data) payable returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) DepositTransaction(_to common.Address, _value *big.Int, _gasLimit uint64, _isCreation bool, _data []byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DepositTransaction(&_OptimismPortal2.TransactOpts, _to, _value, _gasLimit, _isCreation, _data)
+}
+
+// DonateETH is a paid mutator transaction binding the contract method 0x8b4c40b0.
+//
+// Solidity: function donateETH() payable returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) DonateETH(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "donateETH")
+}
+
+// DonateETH is a paid mutator transaction binding the contract method 0x8b4c40b0.
+//
+// Solidity: function donateETH() payable returns()
+func (_OptimismPortal2 *OptimismPortal2Session) DonateETH() (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DonateETH(&_OptimismPortal2.TransactOpts)
+}
+
+// DonateETH is a paid mutator transaction binding the contract method 0x8b4c40b0.
+//
+// Solidity: function donateETH() payable returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) DonateETH() (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.DonateETH(&_OptimismPortal2.TransactOpts)
+}
+
+// FinalizeWithdrawalTransaction is a paid mutator transaction binding the contract method 0x8c3152e9.
+//
+// Solidity: function finalizeWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) FinalizeWithdrawalTransaction(opts *bind.TransactOpts, _tx TypesWithdrawalTransaction) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "finalizeWithdrawalTransaction", _tx)
+}
+
+// FinalizeWithdrawalTransaction is a paid mutator transaction binding the contract method 0x8c3152e9.
+//
+// Solidity: function finalizeWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) FinalizeWithdrawalTransaction(_tx TypesWithdrawalTransaction) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.FinalizeWithdrawalTransaction(&_OptimismPortal2.TransactOpts, _tx)
+}
+
+// FinalizeWithdrawalTransaction is a paid mutator transaction binding the contract method 0x8c3152e9.
+//
+// Solidity: function finalizeWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) FinalizeWithdrawalTransaction(_tx TypesWithdrawalTransaction) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.FinalizeWithdrawalTransaction(&_OptimismPortal2.TransactOpts, _tx)
+}
+
+// FinalizeWithdrawalTransactionExternalProof is a paid mutator transaction binding the contract method 0x43ca1c50.
+//
+// Solidity: function finalizeWithdrawalTransactionExternalProof((uint256,address,address,uint256,uint256,bytes) _tx, address _proofSubmitter) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) FinalizeWithdrawalTransactionExternalProof(opts *bind.TransactOpts, _tx TypesWithdrawalTransaction, _proofSubmitter common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "finalizeWithdrawalTransactionExternalProof", _tx, _proofSubmitter)
+}
+
+// FinalizeWithdrawalTransactionExternalProof is a paid mutator transaction binding the contract method 0x43ca1c50.
+//
+// Solidity: function finalizeWithdrawalTransactionExternalProof((uint256,address,address,uint256,uint256,bytes) _tx, address _proofSubmitter) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) FinalizeWithdrawalTransactionExternalProof(_tx TypesWithdrawalTransaction, _proofSubmitter common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.FinalizeWithdrawalTransactionExternalProof(&_OptimismPortal2.TransactOpts, _tx, _proofSubmitter)
+}
+
+// FinalizeWithdrawalTransactionExternalProof is a paid mutator transaction binding the contract method 0x43ca1c50.
+//
+// Solidity: function finalizeWithdrawalTransactionExternalProof((uint256,address,address,uint256,uint256,bytes) _tx, address _proofSubmitter) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) FinalizeWithdrawalTransactionExternalProof(_tx TypesWithdrawalTransaction, _proofSubmitter common.Address) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.FinalizeWithdrawalTransactionExternalProof(&_OptimismPortal2.TransactOpts, _tx, _proofSubmitter)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8e819e54.
+//
+// Solidity: function initialize(address _disputeGameFactory, address _systemConfig, address _superchainConfig, uint32 _initialRespectedGameType) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) Initialize(opts *bind.TransactOpts, _disputeGameFactory common.Address, _systemConfig common.Address, _superchainConfig common.Address, _initialRespectedGameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "initialize", _disputeGameFactory, _systemConfig, _superchainConfig, _initialRespectedGameType)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8e819e54.
+//
+// Solidity: function initialize(address _disputeGameFactory, address _systemConfig, address _superchainConfig, uint32 _initialRespectedGameType) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) Initialize(_disputeGameFactory common.Address, _systemConfig common.Address, _superchainConfig common.Address, _initialRespectedGameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.Initialize(&_OptimismPortal2.TransactOpts, _disputeGameFactory, _systemConfig, _superchainConfig, _initialRespectedGameType)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8e819e54.
+//
+// Solidity: function initialize(address _disputeGameFactory, address _systemConfig, address _superchainConfig, uint32 _initialRespectedGameType) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) Initialize(_disputeGameFactory common.Address, _systemConfig common.Address, _superchainConfig common.Address, _initialRespectedGameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.Initialize(&_OptimismPortal2.TransactOpts, _disputeGameFactory, _systemConfig, _superchainConfig, _initialRespectedGameType)
+}
+
+// ProveWithdrawalTransaction is a paid mutator transaction binding the contract method 0x4870496f.
+//
+// Solidity: function proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx, uint256 _disputeGameIndex, (bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes[] _withdrawalProof) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) ProveWithdrawalTransaction(opts *bind.TransactOpts, _tx TypesWithdrawalTransaction, _disputeGameIndex *big.Int, _outputRootProof TypesOutputRootProof, _withdrawalProof [][]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "proveWithdrawalTransaction", _tx, _disputeGameIndex, _outputRootProof, _withdrawalProof)
+}
+
+// ProveWithdrawalTransaction is a paid mutator transaction binding the contract method 0x4870496f.
+//
+// Solidity: function proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx, uint256 _disputeGameIndex, (bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes[] _withdrawalProof) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) ProveWithdrawalTransaction(_tx TypesWithdrawalTransaction, _disputeGameIndex *big.Int, _outputRootProof TypesOutputRootProof, _withdrawalProof [][]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.ProveWithdrawalTransaction(&_OptimismPortal2.TransactOpts, _tx, _disputeGameIndex, _outputRootProof, _withdrawalProof)
+}
+
+// ProveWithdrawalTransaction is a paid mutator transaction binding the contract method 0x4870496f.
+//
+// Solidity: function proveWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes) _tx, uint256 _disputeGameIndex, (bytes32,bytes32,bytes32,bytes32) _outputRootProof, bytes[] _withdrawalProof) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) ProveWithdrawalTransaction(_tx TypesWithdrawalTransaction, _disputeGameIndex *big.Int, _outputRootProof TypesOutputRootProof, _withdrawalProof [][]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.ProveWithdrawalTransaction(&_OptimismPortal2.TransactOpts, _tx, _disputeGameIndex, _outputRootProof, _withdrawalProof)
+}
+
+// SetGasPayingToken is a paid mutator transaction binding the contract method 0x71cfaa3f.
+//
+// Solidity: function setGasPayingToken(address _token, uint8 _decimals, bytes32 _name, bytes32 _symbol) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) SetGasPayingToken(opts *bind.TransactOpts, _token common.Address, _decimals uint8, _name [32]byte, _symbol [32]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "setGasPayingToken", _token, _decimals, _name, _symbol)
+}
+
+// SetGasPayingToken is a paid mutator transaction binding the contract method 0x71cfaa3f.
+//
+// Solidity: function setGasPayingToken(address _token, uint8 _decimals, bytes32 _name, bytes32 _symbol) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) SetGasPayingToken(_token common.Address, _decimals uint8, _name [32]byte, _symbol [32]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.SetGasPayingToken(&_OptimismPortal2.TransactOpts, _token, _decimals, _name, _symbol)
+}
+
+// SetGasPayingToken is a paid mutator transaction binding the contract method 0x71cfaa3f.
+//
+// Solidity: function setGasPayingToken(address _token, uint8 _decimals, bytes32 _name, bytes32 _symbol) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) SetGasPayingToken(_token common.Address, _decimals uint8, _name [32]byte, _symbol [32]byte) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.SetGasPayingToken(&_OptimismPortal2.TransactOpts, _token, _decimals, _name, _symbol)
+}
+
+// SetRespectedGameType is a paid mutator transaction binding the contract method 0x7fc48504.
+//
+// Solidity: function setRespectedGameType(uint32 _gameType) returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) SetRespectedGameType(opts *bind.TransactOpts, _gameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.Transact(opts, "setRespectedGameType", _gameType)
+}
+
+// SetRespectedGameType is a paid mutator transaction binding the contract method 0x7fc48504.
+//
+// Solidity: function setRespectedGameType(uint32 _gameType) returns()
+func (_OptimismPortal2 *OptimismPortal2Session) SetRespectedGameType(_gameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.SetRespectedGameType(&_OptimismPortal2.TransactOpts, _gameType)
+}
+
+// SetRespectedGameType is a paid mutator transaction binding the contract method 0x7fc48504.
+//
+// Solidity: function setRespectedGameType(uint32 _gameType) returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) SetRespectedGameType(_gameType uint32) (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.SetRespectedGameType(&_OptimismPortal2.TransactOpts, _gameType)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_OptimismPortal2 *OptimismPortal2Transactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OptimismPortal2.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_OptimismPortal2 *OptimismPortal2Session) Receive() (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.Receive(&_OptimismPortal2.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_OptimismPortal2 *OptimismPortal2TransactorSession) Receive() (*types.Transaction, error) {
+	return _OptimismPortal2.Contract.Receive(&_OptimismPortal2.TransactOpts)
+}
+
+// OptimismPortal2DisputeGameBlacklistedIterator is returned from FilterDisputeGameBlacklisted and is used to iterate over the raw logs and unpacked data for DisputeGameBlacklisted events raised by the OptimismPortal2 contract.
+type OptimismPortal2DisputeGameBlacklistedIterator struct {
+	Event *OptimismPortal2DisputeGameBlacklisted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2DisputeGameBlacklistedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2DisputeGameBlacklisted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2DisputeGameBlacklisted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2DisputeGameBlacklistedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2DisputeGameBlacklistedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2DisputeGameBlacklisted represents a DisputeGameBlacklisted event raised by the OptimismPortal2 contract.
+type OptimismPortal2DisputeGameBlacklisted struct {
+	DisputeGame common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterDisputeGameBlacklisted is a free log retrieval operation binding the contract event 0x192c289026d59a41a27f5aea08f3969b57931b0589202d14f4368cded95d3cda.
+//
+// Solidity: event DisputeGameBlacklisted(address indexed disputeGame)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterDisputeGameBlacklisted(opts *bind.FilterOpts, disputeGame []common.Address) (*OptimismPortal2DisputeGameBlacklistedIterator, error) {
+
+	var disputeGameRule []interface{}
+	for _, disputeGameItem := range disputeGame {
+		disputeGameRule = append(disputeGameRule, disputeGameItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "DisputeGameBlacklisted", disputeGameRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2DisputeGameBlacklistedIterator{contract: _OptimismPortal2.contract, event: "DisputeGameBlacklisted", logs: logs, sub: sub}, nil
+}
+
+// WatchDisputeGameBlacklisted is a free log subscription operation binding the contract event 0x192c289026d59a41a27f5aea08f3969b57931b0589202d14f4368cded95d3cda.
+//
+// Solidity: event DisputeGameBlacklisted(address indexed disputeGame)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchDisputeGameBlacklisted(opts *bind.WatchOpts, sink chan<- *OptimismPortal2DisputeGameBlacklisted, disputeGame []common.Address) (event.Subscription, error) {
+
+	var disputeGameRule []interface{}
+	for _, disputeGameItem := range disputeGame {
+		disputeGameRule = append(disputeGameRule, disputeGameItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "DisputeGameBlacklisted", disputeGameRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2DisputeGameBlacklisted)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "DisputeGameBlacklisted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDisputeGameBlacklisted is a log parse operation binding the contract event 0x192c289026d59a41a27f5aea08f3969b57931b0589202d14f4368cded95d3cda.
+//
+// Solidity: event DisputeGameBlacklisted(address indexed disputeGame)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseDisputeGameBlacklisted(log types.Log) (*OptimismPortal2DisputeGameBlacklisted, error) {
+	event := new(OptimismPortal2DisputeGameBlacklisted)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "DisputeGameBlacklisted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2InitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the OptimismPortal2 contract.
+type OptimismPortal2InitializedIterator struct {
+	Event *OptimismPortal2Initialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2InitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2Initialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2Initialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2InitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2InitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2Initialized represents a Initialized event raised by the OptimismPortal2 contract.
+type OptimismPortal2Initialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterInitialized(opts *bind.FilterOpts) (*OptimismPortal2InitializedIterator, error) {
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2InitializedIterator{contract: _OptimismPortal2.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *OptimismPortal2Initialized) (event.Subscription, error) {
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2Initialized)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseInitialized(log types.Log) (*OptimismPortal2Initialized, error) {
+	event := new(OptimismPortal2Initialized)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2RespectedGameTypeSetIterator is returned from FilterRespectedGameTypeSet and is used to iterate over the raw logs and unpacked data for RespectedGameTypeSet events raised by the OptimismPortal2 contract.
+type OptimismPortal2RespectedGameTypeSetIterator struct {
+	Event *OptimismPortal2RespectedGameTypeSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2RespectedGameTypeSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2RespectedGameTypeSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2RespectedGameTypeSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2RespectedGameTypeSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2RespectedGameTypeSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2RespectedGameTypeSet represents a RespectedGameTypeSet event raised by the OptimismPortal2 contract.
+type OptimismPortal2RespectedGameTypeSet struct {
+	NewGameType uint32
+	UpdatedAt   uint64
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterRespectedGameTypeSet is a free log retrieval operation binding the contract event 0x049fe9dd413cdf037cce27011cc1790c753118272f3630e6e8bdfa5e82081760.
+//
+// Solidity: event RespectedGameTypeSet(uint32 indexed newGameType, uint64 indexed updatedAt)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterRespectedGameTypeSet(opts *bind.FilterOpts, newGameType []uint32, updatedAt []uint64) (*OptimismPortal2RespectedGameTypeSetIterator, error) {
+
+	var newGameTypeRule []interface{}
+	for _, newGameTypeItem := range newGameType {
+		newGameTypeRule = append(newGameTypeRule, newGameTypeItem)
+	}
+	var updatedAtRule []interface{}
+	for _, updatedAtItem := range updatedAt {
+		updatedAtRule = append(updatedAtRule, updatedAtItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "RespectedGameTypeSet", newGameTypeRule, updatedAtRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2RespectedGameTypeSetIterator{contract: _OptimismPortal2.contract, event: "RespectedGameTypeSet", logs: logs, sub: sub}, nil
+}
+
+// WatchRespectedGameTypeSet is a free log subscription operation binding the contract event 0x049fe9dd413cdf037cce27011cc1790c753118272f3630e6e8bdfa5e82081760.
+//
+// Solidity: event RespectedGameTypeSet(uint32 indexed newGameType, uint64 indexed updatedAt)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchRespectedGameTypeSet(opts *bind.WatchOpts, sink chan<- *OptimismPortal2RespectedGameTypeSet, newGameType []uint32, updatedAt []uint64) (event.Subscription, error) {
+
+	var newGameTypeRule []interface{}
+	for _, newGameTypeItem := range newGameType {
+		newGameTypeRule = append(newGameTypeRule, newGameTypeItem)
+	}
+	var updatedAtRule []interface{}
+	for _, updatedAtItem := range updatedAt {
+		updatedAtRule = append(updatedAtRule, updatedAtItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "RespectedGameTypeSet", newGameTypeRule, updatedAtRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2RespectedGameTypeSet)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "RespectedGameTypeSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRespectedGameTypeSet is a log parse operation binding the contract event 0x049fe9dd413cdf037cce27011cc1790c753118272f3630e6e8bdfa5e82081760.
+//
+// Solidity: event RespectedGameTypeSet(uint32 indexed newGameType, uint64 indexed updatedAt)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseRespectedGameTypeSet(log types.Log) (*OptimismPortal2RespectedGameTypeSet, error) {
+	event := new(OptimismPortal2RespectedGameTypeSet)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "RespectedGameTypeSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2TransactionDepositedIterator is returned from FilterTransactionDeposited and is used to iterate over the raw logs and unpacked data for TransactionDeposited events raised by the OptimismPortal2 contract.
+type OptimismPortal2TransactionDepositedIterator struct {
+	Event *OptimismPortal2TransactionDeposited // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2TransactionDepositedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2TransactionDeposited)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2TransactionDeposited)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2TransactionDepositedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2TransactionDepositedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2TransactionDeposited represents a TransactionDeposited event raised by the OptimismPortal2 contract.
+type OptimismPortal2TransactionDeposited struct {
+	From       common.Address
+	To         common.Address
+	Version    *big.Int
+	OpaqueData []byte
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransactionDeposited is a free log retrieval operation binding the contract event 0xb3813568d9991fc951961fcb4c784893574240a28925604d09fc577c55bb7c32.
+//
+// Solidity: event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterTransactionDeposited(opts *bind.FilterOpts, from []common.Address, to []common.Address, version []*big.Int) (*OptimismPortal2TransactionDepositedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+	var versionRule []interface{}
+	for _, versionItem := range version {
+		versionRule = append(versionRule, versionItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "TransactionDeposited", fromRule, toRule, versionRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2TransactionDepositedIterator{contract: _OptimismPortal2.contract, event: "TransactionDeposited", logs: logs, sub: sub}, nil
+}
+
+// WatchTransactionDeposited is a free log subscription operation binding the contract event 0xb3813568d9991fc951961fcb4c784893574240a28925604d09fc577c55bb7c32.
+//
+// Solidity: event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchTransactionDeposited(opts *bind.WatchOpts, sink chan<- *OptimismPortal2TransactionDeposited, from []common.Address, to []common.Address, version []*big.Int) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+	var versionRule []interface{}
+	for _, versionItem := range version {
+		versionRule = append(versionRule, versionItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "TransactionDeposited", fromRule, toRule, versionRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2TransactionDeposited)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "TransactionDeposited", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransactionDeposited is a log parse operation binding the contract event 0xb3813568d9991fc951961fcb4c784893574240a28925604d09fc577c55bb7c32.
+//
+// Solidity: event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseTransactionDeposited(log types.Log) (*OptimismPortal2TransactionDeposited, error) {
+	event := new(OptimismPortal2TransactionDeposited)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "TransactionDeposited", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2WithdrawalFinalizedIterator is returned from FilterWithdrawalFinalized and is used to iterate over the raw logs and unpacked data for WithdrawalFinalized events raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalFinalizedIterator struct {
+	Event *OptimismPortal2WithdrawalFinalized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2WithdrawalFinalizedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2WithdrawalFinalized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2WithdrawalFinalized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2WithdrawalFinalizedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2WithdrawalFinalizedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2WithdrawalFinalized represents a WithdrawalFinalized event raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalFinalized struct {
+	WithdrawalHash [32]byte
+	Success        bool
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalFinalized is a free log retrieval operation binding the contract event 0xdb5c7652857aa163daadd670e116628fb42e869d8ac4251ef8971d9e5727df1b.
+//
+// Solidity: event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterWithdrawalFinalized(opts *bind.FilterOpts, withdrawalHash [][32]byte) (*OptimismPortal2WithdrawalFinalizedIterator, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "WithdrawalFinalized", withdrawalHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2WithdrawalFinalizedIterator{contract: _OptimismPortal2.contract, event: "WithdrawalFinalized", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalFinalized is a free log subscription operation binding the contract event 0xdb5c7652857aa163daadd670e116628fb42e869d8ac4251ef8971d9e5727df1b.
+//
+// Solidity: event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchWithdrawalFinalized(opts *bind.WatchOpts, sink chan<- *OptimismPortal2WithdrawalFinalized, withdrawalHash [][32]byte) (event.Subscription, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "WithdrawalFinalized", withdrawalHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2WithdrawalFinalized)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalFinalized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalFinalized is a log parse operation binding the contract event 0xdb5c7652857aa163daadd670e116628fb42e869d8ac4251ef8971d9e5727df1b.
+//
+// Solidity: event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseWithdrawalFinalized(log types.Log) (*OptimismPortal2WithdrawalFinalized, error) {
+	event := new(OptimismPortal2WithdrawalFinalized)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalFinalized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2WithdrawalProvenIterator is returned from FilterWithdrawalProven and is used to iterate over the raw logs and unpacked data for WithdrawalProven events raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalProvenIterator struct {
+	Event *OptimismPortal2WithdrawalProven // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2WithdrawalProvenIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2WithdrawalProven)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2WithdrawalProven)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2WithdrawalProvenIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2WithdrawalProvenIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2WithdrawalProven represents a WithdrawalProven event raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalProven struct {
+	WithdrawalHash [32]byte
+	From           common.Address
+	To             common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalProven is a free log retrieval operation binding the contract event 0x67a6208cfcc0801d50f6cbe764733f4fddf66ac0b04442061a8a8c0cb6b63f62.
+//
+// Solidity: event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterWithdrawalProven(opts *bind.FilterOpts, withdrawalHash [][32]byte, from []common.Address, to []common.Address) (*OptimismPortal2WithdrawalProvenIterator, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "WithdrawalProven", withdrawalHashRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2WithdrawalProvenIterator{contract: _OptimismPortal2.contract, event: "WithdrawalProven", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalProven is a free log subscription operation binding the contract event 0x67a6208cfcc0801d50f6cbe764733f4fddf66ac0b04442061a8a8c0cb6b63f62.
+//
+// Solidity: event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchWithdrawalProven(opts *bind.WatchOpts, sink chan<- *OptimismPortal2WithdrawalProven, withdrawalHash [][32]byte, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "WithdrawalProven", withdrawalHashRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2WithdrawalProven)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalProven", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalProven is a log parse operation binding the contract event 0x67a6208cfcc0801d50f6cbe764733f4fddf66ac0b04442061a8a8c0cb6b63f62.
+//
+// Solidity: event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseWithdrawalProven(log types.Log) (*OptimismPortal2WithdrawalProven, error) {
+	event := new(OptimismPortal2WithdrawalProven)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalProven", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OptimismPortal2WithdrawalProvenExtension1Iterator is returned from FilterWithdrawalProvenExtension1 and is used to iterate over the raw logs and unpacked data for WithdrawalProvenExtension1 events raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalProvenExtension1Iterator struct {
+	Event *OptimismPortal2WithdrawalProvenExtension1 // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OptimismPortal2WithdrawalProvenExtension1Iterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OptimismPortal2WithdrawalProvenExtension1)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OptimismPortal2WithdrawalProvenExtension1)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OptimismPortal2WithdrawalProvenExtension1Iterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OptimismPortal2WithdrawalProvenExtension1Iterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OptimismPortal2WithdrawalProvenExtension1 represents a WithdrawalProvenExtension1 event raised by the OptimismPortal2 contract.
+type OptimismPortal2WithdrawalProvenExtension1 struct {
+	WithdrawalHash [32]byte
+	ProofSubmitter common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrawalProvenExtension1 is a free log retrieval operation binding the contract event 0x798f9f13695f8f045aa5f80ed8efebb695f3c7fe65da381969f2f28bf3c60b97.
+//
+// Solidity: event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter)
+func (_OptimismPortal2 *OptimismPortal2Filterer) FilterWithdrawalProvenExtension1(opts *bind.FilterOpts, withdrawalHash [][32]byte, proofSubmitter []common.Address) (*OptimismPortal2WithdrawalProvenExtension1Iterator, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+	var proofSubmitterRule []interface{}
+	for _, proofSubmitterItem := range proofSubmitter {
+		proofSubmitterRule = append(proofSubmitterRule, proofSubmitterItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.FilterLogs(opts, "WithdrawalProvenExtension1", withdrawalHashRule, proofSubmitterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OptimismPortal2WithdrawalProvenExtension1Iterator{contract: _OptimismPortal2.contract, event: "WithdrawalProvenExtension1", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrawalProvenExtension1 is a free log subscription operation binding the contract event 0x798f9f13695f8f045aa5f80ed8efebb695f3c7fe65da381969f2f28bf3c60b97.
+//
+// Solidity: event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter)
+func (_OptimismPortal2 *OptimismPortal2Filterer) WatchWithdrawalProvenExtension1(opts *bind.WatchOpts, sink chan<- *OptimismPortal2WithdrawalProvenExtension1, withdrawalHash [][32]byte, proofSubmitter []common.Address) (event.Subscription, error) {
+
+	var withdrawalHashRule []interface{}
+	for _, withdrawalHashItem := range withdrawalHash {
+		withdrawalHashRule = append(withdrawalHashRule, withdrawalHashItem)
+	}
+	var proofSubmitterRule []interface{}
+	for _, proofSubmitterItem := range proofSubmitter {
+		proofSubmitterRule = append(proofSubmitterRule, proofSubmitterItem)
+	}
+
+	logs, sub, err := _OptimismPortal2.contract.WatchLogs(opts, "WithdrawalProvenExtension1", withdrawalHashRule, proofSubmitterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OptimismPortal2WithdrawalProvenExtension1)
+				if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalProvenExtension1", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseWithdrawalProvenExtension1 is a log parse operation binding the contract event 0x798f9f13695f8f045aa5f80ed8efebb695f3c7fe65da381969f2f28bf3c60b97.
+//
+// Solidity: event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter)
+func (_OptimismPortal2 *OptimismPortal2Filterer) ParseWithdrawalProvenExtension1(log types.Log) (*OptimismPortal2WithdrawalProvenExtension1, error) {
+	event := new(OptimismPortal2WithdrawalProvenExtension1)
+	if err := _OptimismPortal2.contract.UnpackLog(event, "WithdrawalProvenExtension1", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/op-monitorism/withdrawals-v2/cli.go
+++ b/op-monitorism/withdrawals-v2/cli.go
@@ -1,0 +1,71 @@
+package withdrawalsv2
+
+import (
+	"time"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	L1NodeURLFlagName             = "l1.node.url"
+	L2NodeURLFlagName             = "l2.node.url"
+	StartBlockFlagName            = "start.block"
+	PollingIntervalFlagName       = "poll.interval"
+	OptimismPortalAddressFlagName = "optimism.portal.address"
+)
+
+type CLIConfig struct {
+	L1NodeURL             string
+	L2NodeURL             string
+	OptimismPortalAddress string
+	StartBlock            uint64
+	PollingInterval       time.Duration
+}
+
+func ReadCLIFlags(ctx *cli.Context) (CLIConfig, error) {
+	cfg := CLIConfig{
+		L1NodeURL:             ctx.String(L1NodeURLFlagName),
+		L2NodeURL:             ctx.String(L2NodeURLFlagName),
+		OptimismPortalAddress: ctx.String(OptimismPortalAddressFlagName),
+		StartBlock:            ctx.Uint64(StartBlockFlagName),
+		PollingInterval:       ctx.Duration(PollingIntervalFlagName),
+	}
+
+	return cfg, nil
+}
+
+func CLIFlags(envVar string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     L1NodeURLFlagName,
+			Usage:    "Node URL of L1 peer Geth node",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "L1_NODE_URL"),
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     L2NodeURLFlagName,
+			Usage:    "Node URL of L2 peer Op-Geth node",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "L2_NODE_URL"),
+			Required: true,
+		},
+		&cli.Uint64Flag{
+			Name:     StartBlockFlagName,
+			Usage:    "Starting L1 block number to scan",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "START_BLOCK"),
+			Required: true,
+		},
+		&cli.DurationFlag{
+			Name:    PollingIntervalFlagName,
+			Usage:   "Polling interval for scanning L1 blocks",
+			EnvVars: opservice.PrefixEnvVar(envVar, "POLL_INTERVAL"),
+			Value:   time.Second,
+		},
+		&cli.StringFlag{
+			Name:     OptimismPortalAddressFlagName,
+			Usage:    "Address of the OptimismPortal2 contract",
+			EnvVars:  opservice.PrefixEnvVar(envVar, "OPTIMISM_PORTAL"),
+			Required: true,
+		},
+	}
+}

--- a/op-monitorism/withdrawals-v2/monitor.go
+++ b/op-monitorism/withdrawals-v2/monitor.go
@@ -1,0 +1,325 @@
+package withdrawalsv2
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+
+	"github.com/ethereum-optimism/monitorism/op-monitorism/processor"
+	"github.com/ethereum-optimism/monitorism/op-monitorism/withdrawals-v2/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	MetricsNamespace = "withdrawals_v2"
+)
+
+type Metrics struct {
+	validWithdrawals   *prometheus.CounterVec
+	invalidWithdrawals *prometheus.CounterVec
+}
+
+type Monitor struct {
+	log           log.Logger
+	l1Client      *ethclient.Client
+	l2Client      *ethclient.Client
+	portal        *bindings.OptimismPortal2
+	portalAddress common.Address
+	processor     *processor.BlockProcessor
+	metrics       Metrics
+}
+
+func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIConfig) (*Monitor, error) {
+	log.Info("creating withdrawals v2 monitor")
+
+	l1Client, err := ethclient.Dial(cfg.L1NodeURL)
+	if err != nil {
+		return nil, err
+	}
+
+	l2Client, err := ethclient.Dial(cfg.L2NodeURL)
+	if err != nil {
+		return nil, err
+	}
+
+	portalAddress := common.HexToAddress(cfg.OptimismPortalAddress)
+	portal, err := bindings.NewOptimismPortal2(portalAddress, l1Client)
+	if err != nil {
+		return nil, err
+	}
+
+	mon := &Monitor{
+		log:           log,
+		l1Client:      l1Client,
+		l2Client:      l2Client,
+		portal:        portal,
+		portalAddress: portalAddress,
+		metrics: Metrics{
+			validWithdrawals: m.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: MetricsNamespace,
+					Name:      "valid_withdrawals_total",
+					Help:      "Total number of valid withdrawals",
+				},
+				[]string{},
+			),
+			invalidWithdrawals: m.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: MetricsNamespace,
+					Name:      "invalid_withdrawals_total",
+					Help:      "Total number of invalid withdrawals",
+				},
+				[]string{"reason", "txhash", "wdhash"},
+			),
+		},
+	}
+
+	proc, err := processor.NewBlockProcessor(
+		m,
+		log,
+		cfg.L1NodeURL,
+		nil,
+		nil,
+		mon.processLog,
+		&processor.Config{
+			StartBlock: big.NewInt(int64(cfg.StartBlock)),
+			Interval:   cfg.PollingInterval,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	mon.processor = proc
+	return mon, nil
+}
+
+func (m *Monitor) Run(ctx context.Context) {
+	go func() {
+		<-ctx.Done()
+		m.processor.Stop()
+	}()
+
+	if err := m.processor.Start(); err != nil {
+		m.log.Error("processor error", "err", err)
+	}
+}
+
+func (m *Monitor) Close(ctx context.Context) error {
+	m.processor.Stop()
+	m.l1Client.Close()
+	m.l2Client.Close()
+	return nil
+}
+
+// computeWithdrawalStorageKey computes the storage key for a withdrawal hash in the
+// L2ToL1MessagePasser contract. The withdrawal mapping is located in the first storage slot (0)
+// of the L2ToL1MessagePasser contract.
+func computeWithdrawalStorageKey(withdrawalHash [32]byte) common.Hash {
+	return crypto.Keccak256Hash(append(withdrawalHash[:], make([]byte, 32)...))
+}
+
+// determineFailureReason compares the computed output root with the dispute game's root claim to
+// determine the reason for withdrawal validation failure.
+func determineFailureReason(computedOutputRoot eth.Bytes32, disputeGameRootClaim [32]byte) string {
+	if !bytes.Equal(computedOutputRoot[:], disputeGameRootClaim[:]) {
+		// Acceptable case, this can happen normally when dispute game has wrong output root (P3)
+		return "bad_output_root"
+	}
+
+	// Unacceptable case, dispute game is correct but withdrawal proof is invalid (P0)
+	return "bad_withdrawal_proof"
+}
+
+// checkWithdrawalExists checks if a withdrawal hash exists in the L2ToL1MessagePasser contract.
+// Returns true if the withdrawal exists, false otherwise.
+func checkWithdrawalExists(ctx context.Context, l2Client *ethclient.Client, withdrawalHash [32]byte) (bool, error) {
+	// Use eth_getStorageAt to check that the withdrawal hash is actually present on the L2.
+	// We use the latest block, good enough, if it's present on the L2 we're fine with it executing.
+	storageKey := computeWithdrawalStorageKey(withdrawalHash)
+	storageVal, err := l2Client.StorageAt(ctx, predeploys.L2ToL1MessagePasserAddr, storageKey, nil)
+	if err != nil {
+		return false, err
+	}
+
+	// Storage value not empty means withdrawal exists
+	return len(storageVal) > 0, nil
+}
+
+// DisputeGameInfo holds information about a dispute game related to a withdrawal.
+type DisputeGameInfo struct {
+	RootClaim     [32]byte
+	L2BlockNumber *big.Int
+}
+
+// getDisputeGameInfo retrieves dispute game information for a proven withdrawal.
+// Returns the root claim and L2 block number from the dispute game.
+func getDisputeGameInfo(portal *bindings.OptimismPortal2, l1Client *ethclient.Client, withdrawalHash [32]byte, proofSubmitter common.Address) (*DisputeGameInfo, error) {
+	// Get the dispute game info from the provenWithdrawals mapping.
+	disputeGameInfo, err := portal.ProvenWithdrawals(nil, withdrawalHash, proofSubmitter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bind to the dispute game contract.
+	disputeGame, err := bindings.NewFaultDisputeGame(disputeGameInfo.DisputeGameProxy, l1Client)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the root claim.
+	rootClaim, err := disputeGame.RootClaim(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the L2 block number from the dispute game.
+	l2BlockNumber, err := disputeGame.L2BlockNumber(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DisputeGameInfo{
+		RootClaim:     rootClaim,
+		L2BlockNumber: l2BlockNumber,
+	}, nil
+}
+
+// getOutputRoot retrieves the output root for a given L2 block number.
+func getOutputRoot(ctx context.Context, l2Client *ethclient.Client, l2BlockNumber *big.Int) (eth.Bytes32, error) {
+	// Get the L2 block from the client.
+	l2Block, err := l2Client.BlockByNumber(ctx, l2BlockNumber)
+	if err != nil {
+		return eth.Bytes32{}, err
+	}
+
+	// Get the storage root of the L2ToL1MessagePasser contract at the L2 block.
+	proof := struct{ StorageHash common.Hash }{}
+	if err := l2Client.Client().CallContext(ctx, &proof, "eth_getProof", predeploys.L2ToL1MessagePasserAddr, nil, hexutil.EncodeBig(l2Block.Number())); err != nil {
+		return eth.Bytes32{}, err
+	}
+
+	// Generate the output root.
+	outputRoot := eth.OutputRoot(&eth.OutputV0{
+		StateRoot:                eth.Bytes32(l2Block.Root()),
+		MessagePasserStorageRoot: eth.Bytes32(proof.StorageHash),
+		BlockHash:                l2Block.Hash(),
+	})
+
+	return outputRoot, nil
+}
+
+func (m *Monitor) isValidWithdrawal(ctx context.Context, txHash common.Hash, wdHash common.Hash, proofSubmitter common.Address) (bool, string, error) {
+	// Check if the withdrawal exists on the L2.
+	exists, err := checkWithdrawalExists(ctx, m.l2Client, wdHash)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Withdrawal exists on the L2, we can move on.
+	if exists {
+		return true, "", nil
+	}
+
+	// At this point we're looking at an invalid withdrawal. We need to figure out if this withdrawal
+	// is invalid because it's being proven against an invalid dispute game (allowed to happen) or if
+	// it's invalid because it actually managed to trick the withdrawal proving code. Note that we
+	// don't need to bother checking how the games resolve, we assume that other monitoring exists to
+	// check if invalid dispute games are resolving incorrectly.
+	m.log.Info("withdrawal is invalid, performing additional checks", "txHash", txHash.String(), "wdHash", wdHash.String())
+
+	// Get the dispute game info from the provenWithdrawals mapping.
+	disputeGameInfo, err := getDisputeGameInfo(m.portal, m.l1Client, wdHash, proofSubmitter)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Grab the output root from the L2 block number.
+	outputRoot, err := getOutputRoot(ctx, m.l2Client, disputeGameInfo.L2BlockNumber)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Determine failure reason by comparing output roots.
+	reason := determineFailureReason(outputRoot, disputeGameInfo.RootClaim)
+
+	// Log and increment metrics.
+	m.log.Info("withdrawal is invalid", "txHash", txHash.String(), "wdHash", wdHash.String(), "reason", reason)
+	m.metrics.invalidWithdrawals.WithLabelValues(reason, txHash.String(), wdHash.String()).Inc()
+	return false, reason, nil
+}
+
+// parseWithdrawalEvent parses a WithdrawalProvenExtension1 event from a log.
+// Returns the withdrawal proven event if it's a WithdrawalProvenExtension1 event, nil otherwise.
+func (m *Monitor) parseWithdrawalEvent(lg types.Log) (*bindings.OptimismPortal2WithdrawalProvenExtension1, error) {
+	// We only care about events logged by the OptimismPortal2 contract.
+	if lg.Address != m.portalAddress {
+		return nil, nil
+	}
+
+	// Need the ABI so we can get the event ID.
+	abi, err := bindings.OptimismPortal2MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	// We only care about WithdrawalProvenExtension1 events.
+	if lg.Topics[0] != abi.Events["WithdrawalProvenExtension1"].ID {
+		return nil, nil
+	}
+
+	// Parse the withdrawal proven event.
+	provenWithdrawal, err := m.portal.ParseWithdrawalProvenExtension1(lg)
+	if err != nil {
+		return nil, err
+	}
+
+	return provenWithdrawal, nil
+}
+
+func (m *Monitor) processLog(block *types.Block, lg types.Log, client *ethclient.Client) error {
+	ctx := context.Background()
+
+	// Parse the withdrawal proven event.
+	provenWithdrawal, err := m.parseWithdrawalEvent(lg)
+	if err != nil {
+		return err
+	}
+
+	// If this isn't a WithdrawalProvenExtension1 event to the portal, we can move on.
+	if provenWithdrawal == nil {
+		return nil
+	}
+
+	// We actually got a withdrawal proven event, let's process it.
+	txHash := lg.TxHash.String()
+	wdHash := common.BytesToHash(provenWithdrawal.WithdrawalHash[:]).String()
+	m.log.Info("processing withdrawal proven event", "txHash", txHash, "wdHash", wdHash)
+
+	// Check if the withdrawal is valid.
+	isValid, reason, err := m.isValidWithdrawal(ctx, lg.TxHash, common.BytesToHash(provenWithdrawal.WithdrawalHash[:]), provenWithdrawal.ProofSubmitter)
+	if err != nil {
+		return err
+	}
+
+	// Log and increment metrics.
+	if isValid {
+		m.log.Info("withdrawal is valid", "txHash", txHash, "wdHash", wdHash)
+		m.metrics.validWithdrawals.WithLabelValues().Inc()
+	} else {
+		m.log.Info("withdrawal is invalid", "txHash", txHash, "wdHash", wdHash, "reason", reason)
+		m.metrics.invalidWithdrawals.WithLabelValues(reason, txHash, wdHash).Inc()
+	}
+
+	return nil
+}

--- a/op-monitorism/withdrawals-v2/monitor_test.go
+++ b/op-monitorism/withdrawals-v2/monitor_test.go
@@ -1,0 +1,101 @@
+package withdrawalsv2
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeWithdrawalStorageKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		withdrawalHash [32]byte
+		expectedKey    common.Hash
+	}{
+		{
+			name:           "zero hash",
+			withdrawalHash: [32]byte{},
+			expectedKey:    crypto.Keccak256Hash(append(make([]byte, 32), make([]byte, 32)...)),
+		},
+		{
+			name:           "non-zero hash",
+			withdrawalHash: [32]byte{0x01, 0x02, 0x03},
+			expectedKey:    crypto.Keccak256Hash(append([]byte{0x01, 0x02, 0x03}, append(make([]byte, 29), make([]byte, 32)...)...)),
+		},
+		{
+			name:           "specific test vector",
+			withdrawalHash: [32]byte{0xaa, 0xbb, 0xcc, 0xdd},
+			expectedKey:    crypto.Keccak256Hash(append([]byte{0xaa, 0xbb, 0xcc, 0xdd}, append(make([]byte, 28), make([]byte, 32)...)...)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeWithdrawalStorageKey(tt.withdrawalHash)
+			assert.Equal(t, tt.expectedKey, result)
+		})
+	}
+}
+
+func TestDetermineFailureReason(t *testing.T) {
+	tests := []struct {
+		name                 string
+		computedOutputRoot   eth.Bytes32
+		disputeGameRootClaim [32]byte
+		expectedReason       string
+		description          string
+	}{
+		{
+			name:                 "output roots match - bad withdrawal proof",
+			computedOutputRoot:   eth.Bytes32{0xaa, 0xbb, 0xcc},
+			disputeGameRootClaim: [32]byte{0xaa, 0xbb, 0xcc},
+			expectedReason:       "bad_withdrawal_proof",
+			description:          "When output roots match, the dispute game is correct but withdrawal proof is invalid (P0 - serious issue)",
+		},
+		{
+			name:                 "output roots don't match - bad output root",
+			computedOutputRoot:   eth.Bytes32{0xaa, 0xbb, 0xcc},
+			disputeGameRootClaim: [32]byte{0xdd, 0xee, 0xff},
+			expectedReason:       "bad_output_root",
+			description:          "When output roots don't match, dispute game has wrong output root (P3 - acceptable)",
+		},
+		{
+			name:                 "zero values don't match",
+			computedOutputRoot:   eth.Bytes32{},
+			disputeGameRootClaim: [32]byte{0x01},
+			expectedReason:       "bad_output_root",
+			description:          "Zero vs non-zero should be bad output root",
+		},
+		{
+			name:                 "both zero values",
+			computedOutputRoot:   eth.Bytes32{},
+			disputeGameRootClaim: [32]byte{},
+			expectedReason:       "bad_withdrawal_proof",
+			description:          "Both zero means they match - bad withdrawal proof",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineFailureReason(tt.computedOutputRoot, tt.disputeGameRootClaim)
+			assert.Equal(t, tt.expectedReason, result, tt.description)
+		})
+	}
+}
+
+func TestFailureReasonPriority(t *testing.T) {
+	matchingRoots := eth.Bytes32{0x12, 0x34, 0x56}
+	sameRootClaim := [32]byte{0x12, 0x34, 0x56}
+
+	reason := determineFailureReason(matchingRoots, sameRootClaim)
+	assert.Equal(t, "bad_withdrawal_proof", reason,
+		"When output roots match, it should indicate bad_withdrawal_proof (P0 - serious issue)")
+
+	differentRootClaim := [32]byte{0x78, 0x9a, 0xbc}
+	reason = determineFailureReason(matchingRoots, differentRootClaim)
+	assert.Equal(t, "bad_output_root", reason,
+		"When output roots don't match, it should indicate bad_output_root (P3 - acceptable)")
+}


### PR DESCRIPTION
Updated and simplified version of the withdrawal monitor.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR introduces withdrawal monitor v2, a proposed replacement for the faultproof withdrawal monitor. This is a simplified version of the monitor that I've tried to make as reliable as possible without a lot of complex logic. It doesn't have the same node fallback system, but it should also be far more robust to errors in general. If nothing else, it should be much easier to maintain.

**Tests**

Added tests for the pure functions. We really need a framework to be able to test everything else, it's a bit of a nightmare right now to test anything in a production network, I didn't feel like building that framework here.
