### PR TITLE
ci: migrate Docker build matrix to images.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,20 @@ workflows:
         - go-lint:
             name: op-defender-go-lint
             project_name: op-defender
+            context:
+              - circleci-repo-readonly-authenticated-github-token
         - go-lint:
             name: op-monitorism-go-lint
             project_name: op-monitorism
+            context:
+              - circleci-repo-readonly-authenticated-github-token
         - golang-test:
             name: op-defender-golang-test
             project_name: op-defender
+            context:
+              - circleci-repo-readonly-authenticated-github-token
         - golang-test:
             name: op-monitorism-golang-test
             project_name: op-monitorism
+            context:
+              - circleci-repo-readonly-authenticated-github-token

--- a/.github/images.json
+++ b/.github/images.json
@@ -1,0 +1,21 @@
+{
+  "shared_paths": [
+    ".github/workflows/branches.yaml",
+    ".github/images.json",
+    "docker-bake.hcl"
+  ],
+  "images": {
+    "op-monitorism": {
+      "mode": "bake",
+      "bake_file": "docker-bake.hcl",
+      "target": "op-monitorism",
+      "paths": ["op-monitorism/**"]
+    },
+    "op-defender": {
+      "mode": "bake",
+      "bake_file": "docker-bake.hcl",
+      "target": "op-defender",
+      "paths": ["op-defender/**"]
+    }
+  }
+}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -9,22 +9,38 @@ on:
       - 'op-defender/**'
       - 'docker-bake.hcl'
       - '.github/workflows/branches.yaml'
+      - '.github/images.json'
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix_json: ${{ steps.detect.outputs.matrix_json }}
+      has_images: ${{ steps.detect.outputs.has_images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
+        with:
+          fetch-depth: 0
+      - name: Detect affected images
+        id: detect
+        uses: ethereum-optimism/factory/actions/detect-changes@e2dc072bfb0492f579dfab8d0dc9938a35739a9c
+
   build:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_images == 'true' && github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - op-monitorism
-          - op-defender
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
     with:
-      mode: bake
+      mode: ${{ matrix.mode || 'build' }}
       image_name: ${{ matrix.image_name }}
-      bake_file: docker-bake.hcl
-      target: ${{ matrix.image_name }}
+      bake_file: ${{ matrix.bake_file || 'docker-bake.hcl' }}
+      target: ${{ matrix.target || '' }}
       tag: pr-${{ github.event.pull_request.number }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images


### PR DESCRIPTION
## Summary

- Extract hardcoded Docker build matrix into `.github/images.json`
- Update `branches.yaml` to use the `detect-changes` composite action from factory
- Image definitions (names, bake targets, paths) are now managed in `images.json` independently of the workflow file
- Preserves bake mode, fork protection, path filtering, and `set` parameters

No functional change to what gets built. Both images (`op-monitorism`, `op-defender`) continue to build with the same configuration. On PRs, only images affected by changed files will build.

Closes #166

## Test plan

- [ ] Verify CI passes on this PR (only affected images should build)
- [ ] Merge and confirm both images build successfully