### PR TITLE
ci: install foundry in CI for transaction monitor tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install Foundry
+          command: |
+            curl -L https://foundry.paradigm.xyz | bash
+            export PATH="$HOME/.foundry/bin:$PATH"
+            foundryup
+            echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> "$BASH_ENV"
+      - run:
           name: run <<parameters.project_name>> module tests
           command: cd <<parameters.project_name>> && go test ./... -v
 

--- a/op-monitorism/transaction_monitor/monitor_test.go
+++ b/op-monitorism/transaction_monitor/monitor_test.go
@@ -36,9 +36,7 @@ func setupAnvil(t *testing.T) (*devnet.Anvil, *ethclient.Client, string) {
 	logger := log.New()
 
 	anvilRunner, err := devnet.NewAnvil(logger)
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
+	require.NoError(t, err)
 
 	err = anvilRunner.Start()
 	require.NoError(t, err)

--- a/op-monitorism/transaction_monitor/monitor_test.go
+++ b/op-monitorism/transaction_monitor/monitor_test.go
@@ -36,7 +36,9 @@ func setupAnvil(t *testing.T) (*devnet.Anvil, *ethclient.Client, string) {
 	logger := log.New()
 
 	anvilRunner, err := devnet.NewAnvil(logger)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("skipping: %v", err)
+	}
 
 	err = anvilRunner.Start()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Install foundry (anvil) in the `op-monitorism-golang-test` CircleCI job
- The `TestChecks` and `TestTransactionMonitoring` tests require `anvil` in PATH, which was missing from the CI environment

## Test plan

- [ ] Verify `op-monitorism-golang-test` passes with anvil available