### PR TITLE
ci: bump factory workflow to node24-compatible version

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Detect affected images
         id: detect
-        uses: ethereum-optimism/factory/actions/detect-changes@e2dc072bfb0492f579dfab8d0dc9938a35739a9c
+        uses: ethereum-optimism/factory/actions/detect-changes@cc1794a8e99695971560f5354076fbe2ddca9f2e
 
   build:
     needs: [detect-changes]
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@612b1cbbd0d9c659bb6cf90dc6492f8a39288fc5
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       mode: ${{ matrix.mode || 'build' }}
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Detect affected images
         id: detect
-        uses: ethereum-optimism/factory/actions/detect-changes@cc1794a8e99695971560f5354076fbe2ddca9f2e
+        uses: ethereum-optimism/factory/actions/detect-changes@0df70b9f043d552377e641951fe72ca292086e85
 
   build:
     needs: [detect-changes]
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect-changes.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       mode: ${{ matrix.mode || 'build' }}
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
       - name: Parse tag
-        uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
+        uses: ethereum-optimism/factory/actions/parse-tag@0df70b9f043d552377e641951fe72ca292086e85
         id: parse-tag
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
       - name: Parse tag
-        uses: ethereum-optimism/factory/actions/parse-tag@f8f3cb4800e538003134fb5f50cc734c2c98d762
+        uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
         id: parse-tag
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}


### PR DESCRIPTION
## Summary

Bumps all `ethereum-optimism/factory` workflow and action references to `cc1794a8e99695971560f5354076fbe2ddca9f2e` to pick up Node.js 24 compatible action updates ahead of the June 2 GitHub Actions deprecation deadline.

Updated references in:
- `.github/workflows/branches.yaml` (detect-changes action + docker workflow)
- `.github/workflows/tags.yaml` (parse-tag action + docker workflow)

## CI note

The "attest build provenance" step fails with `OCIError: Error uploading artifact to container registry`. This is a regression in the new factory workflow version for PR builds. All other CI checks pass. The attestation issue needs to be fixed in the factory repo.