### PR TITLE
fix(faultproof_withdrawals): default to 28-day restart window; warn on conflicting start args

### DIFF
--- a/op-monitorism/faultproof_withdrawals/README.md
+++ b/op-monitorism/faultproof_withdrawals/README.md
@@ -42,8 +42,8 @@ OPTIONS:
    --l2.geth.url value             L2 OP Stack execution layer client(op-geth) URL [$FAULTPROOF_WITHDRAWAL_MON_L2_OP_GETH_URL]
    --l2.geth.backup.urls value     Backup L2 OP Stack execution layer client URLs (format: name=url,name2=url2) [$FAULTPROOF_WITHDRAWAL_MON_L2_OP_GETH_BACKUP_URLS]
    --event.block.range value       Max block range when scanning for events (default: 1000) [$FAULTPROOF_WITHDRAWAL_MON_EVENT_BLOCK_RANGE]
-   --start.block.height value      Starting height to scan for events. This will take precedence if set. (default: -1) [$FAULTPROOF_WITHDRAWAL_MON_START_BLOCK_HEIGHT]
-   --start.block.hours.ago value   How many hours in the past to start to check for forgery. Default will be 336 (14 days) days if not set. The real block to start from will be found within the hour precision. (default: 0) [$FAULTPROOF_WITHDRAWAL_MON_START_HOURS_IN_THE_PAST]
+   --start.block.height value      Fixed L1 height to start scanning for events from. Takes precedence over --start.block.hours.ago when set (>= 0); leave at the default -1 to start dynamically from --start.block.hours.ago instead. (default: -1) [$FAULTPROOF_WITHDRAWAL_MON_START_BLOCK_HEIGHT]
+   --start.block.hours.ago value   How many hours before the current L1 tip to start scanning for forgeries, recomputed on each (re)start. Defaults to 672 (28 days) when unset. Ignored when --start.block.height is set. The starting block is resolved to within one-hour precision. (default: 0) [$FAULTPROOF_WITHDRAWAL_MON_START_HOURS_IN_THE_PAST]
    --optimismportal.address value  Address of the OptimismPortal contract [$FAULTPROOF_WITHDRAWAL_MON_OPTIMISM_PORTAL]
    --log.level value               The lowest log level that will be output (default: INFO) [$MONITORISM_LOG_LEVEL]
    --log.format value              Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty', (default: text) [$MONITORISM_LOG_FORMAT]
@@ -55,6 +55,19 @@ OPTIONS:
    --loop.interval.msec value      Loop interval of the monitor in milliseconds (default: 60000) [$MONITORISM_LOOP_INTERVAL_MSEC]
    --help, -h                      show help
    ```
+
+## Choosing the start point
+
+On startup the monitor needs an L1 block to begin scanning `WithdrawalProven` events from. There are two mutually exclusive ways to set it:
+
+| Env var | Meaning | Default |
+| --- | --- | --- |
+| `FAULTPROOF_WITHDRAWAL_MON_START_HOURS_IN_THE_PAST` | Start `N` hours before the **current L1 tip**, recomputed on every (re)start. | `672` (28 days) |
+| `FAULTPROOF_WITHDRAWAL_MON_START_BLOCK_HEIGHT` | Start from a **fixed** L1 block height. | `-1` (unset → use hours-ago) |
+
+**Precedence:** if `START_BLOCK_HEIGHT` is set (`>= 0`) it wins and `START_HOURS_IN_THE_PAST` is ignored (the monitor logs a warning if both are set). Leave `START_BLOCK_HEIGHT` unset (`-1`) to use the dynamic window.
+
+**Prefer the hours-ago window for production.** Validating a withdrawal requires an `eth_getProof` against the L2 node at the dispute game's L2 block. Pruned / non-archive L2 nodes (e.g. op-reth) only retain trie state for a recent window (~29 days), so a fixed `START_BLOCK_HEIGHT` older than that window makes every proof fail with `failed to get proof from any node` and the monitor stalls. The 28-day default keeps each restart inside that window. Only pin `START_BLOCK_HEIGHT` when the L2 node is a full **archive** node.
 
 ## Example run on sepolia op chain
 
@@ -72,8 +85,10 @@ export FAULTPROOF_WITHDRAWAL_MON_L2_OP_NODE_URL="$L2_OP_NODE_URL"
 export FAULTPROOF_WITHDRAWAL_MON_L2_OP_GETH_URL="$L2_OP_GETH_URL"
 export FAULTPROOF_WITHDRAWAL_MON_L2_OP_GETH_BACKUP_URLS="$L2_OP_GETH_BACKUP_URLS"
 export FAULTPROOF_WITHDRAWAL_MON_OPTIMISM_PORTAL="0x16Fc5058F25648194471939df75CF27A2fdC48BC"
-export FAULTPROOF_WITHDRAWAL_MON_START_BLOCK_HEIGHT=5914813
 export FAULTPROOF_WITHDRAWAL_MON_EVENT_BLOCK_RANGE=1000
+# Start 28 days before the current L1 tip (recomputed on each restart). See "Choosing the start point".
+# Leave START_BLOCK_HEIGHT unset unless the L2 node is a full archive node.
+export FAULTPROOF_WITHDRAWAL_MON_START_HOURS_IN_THE_PAST=672
 
 go run ./cmd/monitorism faultproof_withdrawals
 ```

--- a/op-monitorism/faultproof_withdrawals/cli.go
+++ b/op-monitorism/faultproof_withdrawals/cli.go
@@ -91,14 +91,14 @@ func CLIFlags(envVar string) []cli.Flag {
 		},
 		&cli.Int64Flag{
 			Name:     StartingL1BlockHeightFlagName,
-			Usage:    "Starting height to scan for events. This will take precedence if set.",
+			Usage:    "Fixed L1 height to start scanning for events from. Takes precedence over --start.block.hours.ago when set (>= 0); leave at the default -1 to start dynamically from --start.block.hours.ago instead.",
 			EnvVars:  opservice.PrefixEnvVar(envVar, "START_BLOCK_HEIGHT"),
 			Required: false,
 			Value:    -1,
 		},
 		&cli.Uint64Flag{
 			Name:     HoursInThePastToStartFromFlagName,
-			Usage:    "How many hours in the past to start to check for forgery. Default will be 336 (14 days) days if not set. The real block to start from will be found within the hour precision.",
+			Usage:    "How many hours before the current L1 tip to start scanning for forgeries, recomputed on each (re)start. Defaults to 672 (28 days) when unset. Ignored when --start.block.height is set. The starting block is resolved to within one-hour precision.",
 			EnvVars:  opservice.PrefixEnvVar(envVar, "START_HOURS_IN_THE_PAST"),
 			Required: false,
 		},

--- a/op-monitorism/faultproof_withdrawals/monitor.go
+++ b/op-monitorism/faultproof_withdrawals/monitor.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	MetricsNamespace                 = "faultproof_withdrawals"
-	DefaultHoursInThePastToStartFrom = 14 * 24 //14 days
+	DefaultHoursInThePastToStartFrom = 28 * 24 // 28 days — kept under the ~29d eth_getProof state-retention window of the op-reth proofs nodes, so a (re)start always begins inside the window the L2 node can still serve proofs for.
 	acceptableDiffSec                = 3600    // 1h
 )
 
@@ -111,13 +111,13 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 			"hoursInPast", hoursInThePastToStartFrom,
 			"defaultHours", DefaultHoursInThePastToStartFrom)
 
-		// in this case is not set how many hours in the past to start from, we use default value that is 14 days.
+		// hours-in-the-past not set either: fall back to the default window (28 days).
 		if hoursInThePastToStartFrom == 0 {
 			hoursInThePastToStartFrom = DefaultHoursInThePastToStartFrom
 			log.Debug("Using default hours in past", "hours", DefaultHoursInThePastToStartFrom)
 		}
 
-		// get the block number closest to the timestamp from two weeks ago
+		// get the block number closest to the timestamp hoursInThePastToStartFrom ago
 		latestL1HeightBigInt := new(big.Int).SetUint64(latestL1Height)
 		log.Debug("Searching for block at approximate time",
 			"latestHeight", latestL1HeightBigInt.String(),
@@ -130,6 +130,12 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 		log.Debug("Found starting block height", "height", startingL1BlockHeight)
 	} else {
 		startingL1BlockHeight = uint64(cfg.StartingL1BlockHeight)
+		// start.block.height takes precedence; if hours-in-the-past was also set it is silently unused, so make that explicit.
+		if cfg.HoursInThePastToStartFrom != 0 {
+			log.Warn("Both start.block.height and start.block.hours.ago are set; start.block.height takes precedence and start.block.hours.ago is ignored",
+				"startBlockHeight", startingL1BlockHeight,
+				"ignoredHoursInPast", cfg.HoursInThePastToStartFrom)
+		}
 		log.Debug("Using provided starting block height", "height", startingL1BlockHeight)
 	}
 


### PR DESCRIPTION
## Problem
`faultproof_withdrawals` validates each proven withdrawal with an `eth_getProof` on the **L2** node, at the dispute game's L2 block. Since the sepolia proofs nodes moved op-geth → **op-reth**, those nodes only retain trie state for ~**1.25M L2 blocks (~29 days)** (measured: proofs serve from `latest-5` down to `~latest-1.2M`, `no state found` beyond that and at the absolute tip). A fixed/old `START_BLOCK_HEIGHT` therefore points at pruned state and every proof fails:

```
failed to get trustedRootClaim from L2 clients 'default': failed to get proof: failed to get proof from any node
```

The monitor then never advances (`withdrawalsProcessed=0`).

## Changes
- **Default window 14d → 28d** (`DefaultHoursInThePastToStartFrom`). When `START_BLOCK_HEIGHT` is unset, the monitor already starts from `L1 tip − N hours` recomputed on every (re)start; 28d keeps that start safely inside the op-reth ~29d retention window without any per-deploy config.
- **Warn on conflicting start args.** If both `start.block.height` and `start.block.hours.ago` are set, `start.block.height` silently won. It now logs a `Warn` so the ignored value is visible (answering "what happens if both are set": no crash, height wins, hours-ago ignored).
- **README:** new "Choosing the start point" section documenting both envs + precedence + the op-reth rationale; clearer `--help` text; the example now uses `START_HOURS_IN_THE_PAST=672` instead of pinning `START_BLOCK_HEIGHT` (the anti-pattern that caused the stall).

## Behavior
| Config | Start point |
|---|---|
| neither set | tip − 28d (new default) |
| only `START_HOURS_IN_THE_PAST=N` | tip − N hours |
| `START_BLOCK_HEIGHT=B` (any) | block B; hours-ago ignored (now warns) |

## Validation
`go build`, `go vet`, `go test ./faultproof_withdrawals/...`, `gofmt`, and the CI `golangci-lint` set (`goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint`) all pass.

## Refs
- k8s temporary fix: ethereum-optimism/k8s#11968
- tracking issue: ethereum-optimism/core-team#2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)