### PR TITLE
ci: add dependency-review PR gate via shared factory reusable

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,10 @@
+name: Dependency Review
+
+on: pull_request
+
+jobs:
+  dependency-review:
+    uses: ethereum-optimism/factory/.github/workflows/dependency-review.yaml@0a5a01da201169813de992b8c2dac6e7999f5d51
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Adds a diff-aware dependency CVE gate: a thin caller of the shared reusable Dependency Review workflow in the `factory` repo (pinned by SHA). It fails a PR only on **High/Critical** dependency vulnerabilities the PR **introduces** (GitHub Dependency Review API, base-vs-head); it does not flag the pre-existing backlog. Severity policy is fixed centrally in `factory`.