### PR TITLE
ci: add Renovate CVE autobump (self-hosted, via factory reusable workflow)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,25 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level (debug|info|warn)."
+        type: string
+        default: "info"
+      dryRun:
+        description: "Dry run (no PRs)."
+        type: boolean
+        default: false
+
+jobs:
+  renovate:
+    uses: ethereum-optimism/factory/.github/workflows/renovate.yaml@0e7698dcc639d694b5751e7168918aab481a0767
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      dryRun: ${{ inputs.dryRun || false }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ethereum-optimism/factory:renovate-config"]
+}


### PR DESCRIPTION
## What

- `.github/workflows/renovate.yaml` — thin caller invoking the shared
  self-hosted Renovate reusable workflow in `factory` (SHA-pinned). Runs daily
  and on manual `workflow_dispatch` (with a `dryRun` toggle). App credentials
  come from org secrets via `secrets: inherit`.
- `renovate.json` — thin config that extends the org CVE-only baseline
  (`github>ethereum-optimism/factory:renovate-config`).

## Behaviour

CVE-only: all generic version updates are disabled; Renovate raises PRs solely
for GitHub + OSV vulnerability advisories, surfaced on a per-repo dependency
dashboard. Repo-specific tweaks (grouping, extra labels) can be added to this
`renovate.json` on top of the baseline.

## Notes

- Execution and credentials stay in our own Actions (self-hosted engine, org
  Renovate GitHub App identity).
- Pinned to `factory@0e7698d`; the nested actions are SHA-pinned in `factory`.
