### PR TITLE
ci: make cloud-security sole owner of CI and renovate files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 *   @ethereum-optimism/security-reviewers  @ethereum-optimism/platform-security @hdcesario-op
+
+/.github/workflows/     @ethereum-optimism/cloud-security
+/.github/actions/       @ethereum-optimism/cloud-security
+/renovate.json          @ethereum-optimism/cloud-security
+/.github/renovate.json  @ethereum-optimism/cloud-security
+/renovate.json5         @ethereum-optimism/cloud-security
+/.github/CODEOWNERS      @ethereum-optimism/cloud-security


### PR DESCRIPTION
Makes `@ethereum-optimism/cloud-security` the sole owner of CI and dependency-config files (`.github/workflows/`, `.github/actions/`, renovate config, and CODEOWNERS itself), so security-gate changes are governed and mergeable by the security team.