### PR TITLE
build(go): pin monitorism to Go 1.26.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: cimg/go:1.26
+      - image: cimg/go:1.26.5
         user: root
     steps:
       - checkout

--- a/op-monitorism/go.mod
+++ b/op-monitorism/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum-optimism/monitorism/op-monitorism
 
 go 1.26.0
 
+toolchain go1.26.5
+
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.1
 
 require (


### PR DESCRIPTION
## Summary

- require the Go 1.26.5 toolchain for `op-monitorism`
- pin the CircleCI Go lint image to 1.26.5

## Testing

- CircleCI Go tests and lint
- local Go 1.26.5 build and lint