### PR TITLE
ci(dependency-review): wire repo-local exception config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /.github/renovate.json  @ethereum-optimism/cloud-security
 /renovate.json5         @ethereum-optimism/cloud-security
 /.github/CODEOWNERS      @ethereum-optimism/cloud-security
+/.github/dependency-review-config.yml @ethereum-optimism/cloud-security

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,10 @@
+# Dependency Review exceptions for this repo.
+# Owned by @ethereum-optimism/cloud-security (see CODEOWNERS). fail-on-severity is
+# enforced centrally in the factory reusable workflow and cannot be weakened here.
+#
+# To waive a specific advisory a PR would otherwise be blocked on, add its GHSA id
+# under allow-ghsas with a justification, e.g.:
+#
+# allow-ghsas:
+#   - GHSA-xxxx-xxxx-xxxx  # <package> — why safe · owner · review-by 2026-Qx · <ticket>
+allow-ghsas: []

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,7 +4,9 @@ on: pull_request
 
 jobs:
   dependency-review:
-    uses: ethereum-optimism/factory/.github/workflows/dependency-review.yaml@0a5a01da201169813de992b8c2dac6e7999f5d51
+    uses: ethereum-optimism/factory/.github/workflows/dependency-review.yaml@ed703fcc960cbe3f16c3844db11143a33b01b33b
+    with:
+      config-file: .github/dependency-review-config.yml
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Adds a repo-local dependency-review exception mechanism, gated behind cloud-security code ownership.

## Changes
- Bump the reusable `dependency-review` workflow pin to the factory revision that supports `config-file` (factory#52, merged as `ed703fc`).
- Add `.github/dependency-review-config.yml` — starts empty (`allow-ghsas: []`), no behavior change. A commented example shows how to waive a specific advisory.
- CODEOWNERS routes that config file to `@ethereum-optimism/cloud-security` so exceptions require their review.

`fail-on-severity: high` stays enforced centrally in factory and cannot be weakened here (inline `with:` overrides the config file per key).