### PR TITLE
op-monitorism: add apko image build alongside docker build

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -11,5 +11,14 @@
       "target": "op-monitorism",
       "paths": ["op-monitorism/**"]
     }
+  },
+  "apko_images": {
+    "op-monitorism": {
+      "melange_config": "melange/op-monitorism.yaml",
+      "apko_config_dir": "apko",
+      "services": "op-monitorism",
+      "smoke_test": "op-monitorism",
+      "registry": "us-docker.pkg.dev/oplabs-tools-artifacts/images"
+    }
   }
 }

--- a/.github/workflows/apko.yaml
+++ b/.github/workflows/apko.yaml
@@ -1,0 +1,89 @@
+name: apko
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'op-monitorism/v*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix_json: ${{ steps.plan.outputs.matrix_json }}
+      has_builds: ${{ steps.plan.outputs.has_builds }}
+      apko_tag: ${{ steps.tag.outputs.apko_tag }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
+        with:
+          fetch-depth: 0
+
+      - name: Plan apko groups
+        id: plan
+        env:
+          CONFIG: .github/images.json
+        run: |
+          set -euo pipefail
+          MATRIX=$(jq -c '[.apko_images | to_entries[] | .value + {group: .key}]' "$CONFIG")
+          COUNT=$(echo "$MATRIX" | jq 'length')
+          HAS_BUILDS=$( [[ "$COUNT" -gt 0 ]] && echo true || echo false )
+          {
+            echo "matrix_json=$MATRIX"
+            echo "has_builds=$HAS_BUILDS"
+          } >> "$GITHUB_OUTPUT"
+          echo "matrix_json=$MATRIX"
+
+      - name: Compute apko tag
+        id: tag
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            if [[ "$REF_NAME" == */* ]]; then
+              DOCKER_TAG="${REF_NAME#*/}"
+            else
+              DOCKER_TAG="$REF_NAME"
+            fi
+          else
+            DOCKER_TAG="$SHA"
+          fi
+          echo "apko_tag=apko-${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
+          echo "apko_tag=apko-${DOCKER_TAG}"
+
+  build:
+    needs: [plan]
+    if: needs.plan.outputs.has_builds == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.plan.outputs.matrix_json) }}
+    uses: ethereum-optimism/factory/.github/workflows/apko.yaml@fdcd6acceb0cbad90040e0be9f59a1ad60e65a86
+    with:
+      name: ${{ matrix.group }}
+      melange_config: ${{ matrix.melange_config }}
+      services: ${{ matrix.services }}
+      apko_config_dir: ${{ matrix.apko_config_dir }}
+      smoke_test: ${{ matrix.smoke_test || '' }}
+      registry: ${{ matrix.registry }}
+      tag: ${{ needs.plan.outputs.apko_tag }}
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      skip_arm64: true
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write

--- a/.github/workflows/apko.yaml
+++ b/.github/workflows/apko.yaml
@@ -62,8 +62,8 @@ jobs:
           else
             DOCKER_TAG="$SHA"
           fi
-          echo "apko_tag=apko-${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
-          echo "apko_tag=apko-${DOCKER_TAG}"
+          echo "apko_tag=${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
+          echo "apko_tag=${DOCKER_TAG}"
 
   build:
     needs: [plan]
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/apko.yaml@fdcd6acceb0cbad90040e0be9f59a1ad60e65a86
+    uses: ethereum-optimism/factory/.github/workflows/apko.yaml@c09fe439772f9391c9782aa051786f79c78cb7f6
     with:
       name: ${{ matrix.group }}
       melange_config: ${{ matrix.melange_config }}
@@ -81,6 +81,7 @@ jobs:
       smoke_test: ${{ matrix.smoke_test || '' }}
       registry: ${{ matrix.registry }}
       tag: ${{ needs.plan.outputs.apko_tag }}
+      tag_prefix: apko-
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       skip_arm64: true
     permissions:

--- a/.github/workflows/apko.yaml
+++ b/.github/workflows/apko.yaml
@@ -51,6 +51,8 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           if [[ "$REF_TYPE" == "tag" ]]; then
@@ -59,6 +61,8 @@ jobs:
             else
               DOCKER_TAG="$REF_NAME"
             fi
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            DOCKER_TAG="pr-${PR_NUMBER}"
           else
             DOCKER_TAG="$SHA"
           fi

--- a/apko/op-monitorism.apko.yaml
+++ b/apko/op-monitorism.apko.yaml
@@ -1,0 +1,33 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - op-monitorism@local
+
+archs:
+  - amd64
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/local/bin/monitorism
+
+annotations:
+  org.opencontainers.image.source: https://github.com/ethereum-optimism/monitorism
+  org.opencontainers.image.title: op-monitorism

--- a/melange/op-monitorism.yaml
+++ b/melange/op-monitorism.yaml
@@ -20,6 +20,7 @@ environment:
       - go-1.26
   environment:
     CGO_ENABLED: "0"
+    GOFLAGS: -buildvcs=false
 
 pipeline:
   - uses: go/build

--- a/melange/op-monitorism.yaml
+++ b/melange/op-monitorism.yaml
@@ -1,0 +1,35 @@
+package:
+  name: op-monitorism
+  version: "0.0.0"
+  epoch: 0
+  description: op-monitorism — OP Stack chain monitoring
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - git
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: go/build
+    with:
+      modroot: op-monitorism
+      packages: ./cmd/monitorism
+      output: monitorism
+      go-package: go-1.26
+      prefix: usr/local
+      tags: all
+      ldflags: -s -w -X main.GitCommit=${GIT_COMMIT:-unknown} -X main.GitDate=${GIT_DATE:-0}
+
+  - uses: strip


### PR DESCRIPTION
Adds an apko-built image for op-monitorism that publishes in parallel with the existing docker build, using the shared factory reusable apko workflow.

- New `.github/workflows/apko.yaml` calls the factory apko reusable workflow; the plan job reads the `apko_images` entry from `.github/images.json` and computes the tag.
- Images publish to `us-docker.pkg.dev/oplabs-tools-artifacts/images` (same registry as the docker build) with an `apko-` prefixed tag mirroring the docker tag scheme: `apko-<sha>` on main, `apko-<version>` on `op-monitorism/v*` release tags.
- Builds amd64 only, in parity with the docker build.
- The docker build is unchanged.

Closes https://github.com/ethereum-optimism/cloud-security/issues/382
