### PR TITLE
ci: automerge renovate security PRs and run hourly

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "0 6 * * *" # daily 06:00 UTC
+    - cron: "51 * * * *" # hourly, staggered minute to avoid org-wide thundering herd
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ethereum-optimism/factory:renovate-config"]
+  "extends": [
+    "github>ethereum-optimism/factory:renovate-config"
+  ],
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "automergeType": "pr",
+  "platformAutomerge": false,
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary

- enable automerge for Renovate security PRs via the local config override (factory preset unchanged); the CVE-only preset means this applies exclusively to vulnerability-fix PRs
- `automergeType: "pr"` + `platformAutomerge: false` so Renovate merges via API, which is what the repository ruleset's bypass actor (oplabs-renovate) applies to
- `rebaseWhen: "behind-base-branch"` so stale Renovate branches self-refresh before merging
- Renovate schedule moves from daily to hourly (staggered minute)

## Context

Extends the interop-services automerge canary to a repo with a live queue of green security PRs, so the self-merge behavior is observable end to end. Companion ruleset (1 approval + codeowner review for humans, bypass for the Renovate app and cloud-security) is already active.