### PR TITLE
ci: gate lower-severity renovate fixes behind dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,14 @@
   },
   "automergeType": "pr",
   "platformAutomerge": false,
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "description": "Park medium-and-lower vulnerability fixes behind dashboard approval; high and critical flow automatically",
+      "matchJsonata": [
+        "$lowercase(vulnerabilitySeverity) in ['low','moderate','medium']"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
Lower-severity (medium and below) vulnerability fixes queue on the Renovate CVE Dashboard instead of opening PRs automatically; tick the dashboard checkbox to summon one on demand. High/critical fixes are unaffected and continue to open (and merge) automatically. Testing here first before wider rollout.